### PR TITLE
Draft dialog shell usercontrol

### DIFF
--- a/Client/Rubberduck.UI.Xaml/Controls/DialogShell.xaml
+++ b/Client/Rubberduck.UI.Xaml/Controls/DialogShell.xaml
@@ -1,0 +1,98 @@
+﻿<UserControl x:Class="Rubberduck.UI.Xaml.Controls.DialogShell"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:vm="clr-namespace:Rubberduck.UI.Abstract;assembly=Rubberduck.UI"
+             xmlns:local="clr-namespace:Rubberduck.UI.Xaml.Controls"
+             mc:Ignorable="d" 
+             d:DataContext="{d:DesignInstance {x:Type local:DialogShellDesignViewModel}, IsDesignTimeCreatable=True}"
+             d:DesignHeight="300" d:DesignWidth="600">
+    <!--d:DataContext="{d:DesignInstance {x:Type vm:IDialogShellViewModel}, IsDesignTimeCreatable=False}"-->
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="../Styles/DefaultStyle.xaml"/>
+            </ResourceDictionary.MergedDictionaries>
+            <Style TargetType="TextBlock">
+                <Style.Setters>
+                    <Setter Property="Foreground" Value="{StaticResource CaptionDarkBrush}" />
+                </Style.Setters>
+            </Style>
+            <Style x:Key="TitleLabelStyle" TargetType="TextBlock">
+                <Style.Setters>
+                    <Setter Property="FontSize" Value="16" />
+                    <Setter Property="FontWeight" Value="Bold" />
+                    <Setter Property="Foreground" Value="{StaticResource CaptionDarkBrush}" />
+                </Style.Setters>
+            </Style>
+            <Style x:Key="MoreInformationStyle" TargetType="Expander">
+                <Style.Setters>
+                    <Setter Property="Foreground" Value="{StaticResource CaptionDarkBrush}" />
+                </Style.Setters>
+            </Style>            
+            <Style x:Key="ButtonStyle" TargetType="Button">
+                <Style.Setters>
+                    <Setter Property="FontWeight" Value="Bold" />
+                    <Setter Property="Foreground" Value="{StaticResource CaptionDarkBrush}" />
+                    <Setter Property="Padding" Value="5" />
+                </Style.Setters>
+            </Style>
+            <Style x:Key="OptionsTextStyle" TargetType="CheckBox">
+                <Style.Setters>
+                    <Setter Property="FontSize" Value="11" />
+                    <Setter Property="Foreground" Value="{StaticResource CaptionDarkBrush}" />
+                </Style.Setters>
+            </Style>
+        </ResourceDictionary>
+    </UserControl.Resources>
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+        <Grid x:Name="TitleLabelRow" Grid.Row="0">
+            <StackPanel Margin="8,3,8,0" Orientation="Horizontal">
+                <Image Source="{Binding IconSource}" Height="16" />
+                <TextBlock Text="{Binding TitleLabelText}" Style="{StaticResource TitleLabelStyle}" Margin="10,0,0,0" />
+            </StackPanel>
+        </Grid>
+        <Grid x:Name="InstructionsRow" Grid.Row="1" Margin="20,3,20,0">
+            <TextBlock Text="{Binding InstructionsLabelText}" />
+        </Grid>
+        <Border x:Name="ContentsArea" Grid.Row="2" Margin="20,3,20,0" BorderThickness="1" BorderBrush="{StaticResource HighlightBorderActiveBrush}">
+            <ContentControl Content="{Binding MainContentControl}" />
+        </Border>
+        <Grid x:Name="MoreInformationRow" Grid.Row="3" Margin="20,3,20,0" MaxHeight="200">
+            <Expander Header="More information" ExpandDirection="Down" IsExpanded="False" Style="{StaticResource MoreInformationStyle}" d:IsExpanded="True" >
+                <!--<ScrollViewer>-->
+                    <TextBlock Text="{Binding MoreInformationText}" TextWrapping="Wrap" />
+                <!--</ScrollViewer>-->
+            </Expander>
+        </Grid>
+        <Grid x:Name="SeparatorRow" Grid.Row="4">
+            <Separator Margin="10,5,10,5" />
+        </Grid>
+        <Grid x:Name="BottomSection" Grid.Row="5">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+            <Grid Grid.Column="0" HorizontalAlignment="Left" VerticalAlignment="Center">
+                <CheckBox x:Name="OptionCheckbox" Margin="20,10,10,10" Style="{StaticResource OptionsTextStyle}"
+                Content="{Binding OptionLabelText}" Checked="HandleOptionChecked" Unchecked="HandleOptionUnchecked" />
+            </Grid>
+            <Grid Grid.Column="1" HorizontalAlignment="Right">
+                <StackPanel Orientation="Horizontal">
+                    <Button Margin="10,10,10,10" Content="{Binding CancelButtonText}" IsCancel="True" Visibility="{Binding HasCancelButton, Converter={StaticResource BoolToVisibility}}" Style="{StaticResource ButtonStyle}" />
+                    <Button Margin="10,10,10,10" Content="{Binding DefaultButtonText}" IsDefault="True" Style="{StaticResource ButtonStyle}" Background="{StaticResource DefaultButtonBackgroundBrush}" />
+                </StackPanel>
+            </Grid>
+        </Grid>
+    </Grid>
+</UserControl>

--- a/Client/Rubberduck.UI.Xaml/Controls/DialogShell.xaml.cs
+++ b/Client/Rubberduck.UI.Xaml/Controls/DialogShell.xaml.cs
@@ -1,0 +1,43 @@
+﻿using Rubberduck.UI.Abstract;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+
+namespace Rubberduck.UI.Xaml.Controls
+{
+    /// <summary>
+    /// Interaction logic for DialogShell.xaml
+    /// </summary>
+    public partial class DialogShell : UserControl
+    {
+        public DialogShell(IDialogShellViewModel viewModel)
+        {
+            DataContext = viewModel;
+            InitializeComponent();
+        }
+
+        private IDialogShellViewModel ViewModel => DataContext as IDialogShellViewModel;
+
+
+        private void HandleOptionChecked(object sender, RoutedEventArgs e)
+        {
+            ViewModel.OptionIsChecked = true;
+        }
+
+        private void HandleOptionUnchecked(object sender, RoutedEventArgs e)
+        {
+            ViewModel.OptionIsChecked = false;
+        }
+    }
+}

--- a/Client/Rubberduck.UI.Xaml/Rubberduck.UI.Xaml.csproj
+++ b/Client/Rubberduck.UI.Xaml/Rubberduck.UI.Xaml.csproj
@@ -138,6 +138,9 @@
     <Compile Include="Controls\ConsoleControl.xaml.cs">
       <DependentUpon>ConsoleControl.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Controls\DialogShell.xaml.cs">
+      <DependentUpon>DialogShell.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Controls\EditorShellControl.xaml.cs">
       <DependentUpon>EditorShellControl.xaml</DependentUpon>
     </Compile>
@@ -174,6 +177,10 @@
       <SubType>Designer</SubType>
     </Page>
     <Page Include="Controls\ConsoleControl.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Controls\DialogShell.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
@@ -242,6 +249,7 @@
   </ItemGroup>
   <ItemGroup>
     <Content Include="Ducky.ico" />
+    <Compile Include="SampleData\DialogShellDesignViewModel.cs" />
     <Compile Include="SampleData\SyncPanelDesignViewModel.cs" />
     <Compile Include="SampleData\CodePaneDesignViewModel.cs" />
     <Compile Include="SampleData\StatusBarDesignViewModel.cs" />

--- a/Client/Rubberduck.UI.Xaml/SampleData/DialogShellDesignViewModel.cs
+++ b/Client/Rubberduck.UI.Xaml/SampleData/DialogShellDesignViewModel.cs
@@ -1,0 +1,68 @@
+﻿using Rubberduck.UI.Abstract;
+using System;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Media.Imaging;
+
+///<summary>
+///This file provides design-time data for the <see cref="DialogShell.xaml"/> control.
+///This is only to support working in the XAML designer and nothing in this file should be used otherwise.
+///</summary>
+namespace Rubberduck.UI.Xaml.Controls
+{
+    internal class DialogShellDesignViewModel : IDialogShellViewModel
+    {
+        public string TitleText { get; set; } = "Title";
+        public BitmapImage IconSource { get; set; } = new BitmapImage(new Uri("pack://application:,,,/Rubberduck.Resources;component/Icons/Custom/PNG/ObjectEvent.png"));
+        public string TitleLabelText { get; set; } = "Title label text";
+        public string InstructionsLabelText { get; set; } = "Instructions text";
+        public string ContentsText { get; set; } = "Contents text";
+        public UserControl MainContentControl 
+        {
+            get
+            {
+                var control = new UserControl();
+
+                bool showText = true;
+                if (showText)
+                {
+                    var text = new TextBlock { TextWrapping = TextWrapping.Wrap };
+                    Binding textBinding = new Binding("ContentsText")
+                    {
+                        Mode = BindingMode.TwoWay
+                    };
+                    text.SetBinding(TextBlock.TextProperty, textBinding);
+                    Binding minHeightBinding = new Binding("ClientAreaMinHeight")
+                    {
+                        Mode = BindingMode.TwoWay
+                    };
+                    text.SetBinding(TextBlock.MinHeightProperty, minHeightBinding);
+                    var scrollViewer = new ScrollViewer { Content = text };
+                    control.Content = scrollViewer;
+                }
+                else
+                {
+                    var inputBox = new TextBox { TextWrapping = TextWrapping.NoWrap, AcceptsReturn = false, Height=20, VerticalAlignment=VerticalAlignment.Top};
+                    Binding textBinding = new Binding("ContentsText")
+                    {
+                        Mode = BindingMode.TwoWay
+                    };
+                    inputBox.SetBinding(TextBox.TextProperty, textBinding);
+                    control.Content = inputBox;
+                }
+                return control;
+            }
+            set { }
+        }
+        public string MoreInformationText { get; set; } = "More Information goes here...";
+        public string OptionLabelText { get; set; } = "Option label";
+        public bool OptionIsChecked { get; set; } = true;
+        public string CancelButtonText { get; set; } = "Cancel";
+        public string DefaultButtonText { get; set; } = "Default";
+        public bool HasOption { get; set; } = true;
+        public bool HasCancelButton { get; set; } = true;
+        public bool CanResize { get; set; } = true;
+        public int ClientAreaMinHeight { get; set; } = 100;
+    }
+}

--- a/Client/Rubberduck.UI.Xaml/Styles/LightBlueTheme.xaml
+++ b/Client/Rubberduck.UI.Xaml/Styles/LightBlueTheme.xaml
@@ -50,7 +50,9 @@
     <Color x:Key="ToolBarMenuBorderColor">#FFB6BDC5</Color>
     <Color x:Key="ToolBarSubMenuBackgroundColor">#FFEEF5FD</Color>
 
-    <SolidColorBrush x:Key="HighlightGradientStartBrush" Color="{StaticResource HighlightGradientStartColor}"/>
+    <Color x:Key="DefaultButtonBackgroundColor">#FF345DA1</Color>
+
+        <SolidColorBrush x:Key="HighlightGradientStartBrush" Color="{StaticResource HighlightGradientStartColor}"/>
     <SolidColorBrush x:Key="HighlightGradientEndBrush" Color="{StaticResource HighlightGradientEndColor}"/>
     <SolidColorBrush x:Key="ControlGradientStartBrush" Color="{StaticResource ControlGradientStartColor}"/>
     <SolidColorBrush x:Key="ControlGradientEndBrush" Color="{StaticResource ControlGradientEndColor}"/>
@@ -98,6 +100,8 @@
     <SolidColorBrush x:Key="ToolBarToggleButtonHorizontalBackgroundBrush" Color="{StaticResource ToolBarToggleButtonHorizontalBackgroundColor}"/>
     <SolidColorBrush x:Key="ToolBarMenuBorderBrush" Color="{StaticResource ToolBarMenuBorderColor}"/>
     <SolidColorBrush x:Key="ToolBarSubMenuBackgroundBrush" Color="{StaticResource ToolBarSubMenuBackgroundColor}"/>
+
+    <SolidColorBrush x:Key="DefaultButtonBackgroundBrush" Color="{StaticResource DefaultButtonBackgroundColor}" />
 
     <SolidColorBrush x:Key="{x:Static SystemColors.HighlightTextBrushKey}" Color="{StaticResource WhiteColor}" />
     <SolidColorBrush x:Key="{x:Static SystemColors.ControlTextBrushKey}" Color="{StaticResource WhiteColor}" />

--- a/Shared/Rubberduck.UI/Abstract/Editor/IDialogShellViewModel.cs
+++ b/Shared/Rubberduck.UI/Abstract/Editor/IDialogShellViewModel.cs
@@ -1,0 +1,24 @@
+﻿using System.Windows.Controls;
+using System.Windows.Media.Imaging;
+
+namespace Rubberduck.UI.Abstract
+{
+    public interface IDialogShellViewModel
+    {
+        string TitleText { get; set; }
+        BitmapImage IconSource { get; set; }
+        string TitleLabelText { get; set; }
+        string InstructionsLabelText { get; set; }
+        string ContentsText { get; set; }
+        UserControl MainContentControl { get; set; }
+        string MoreInformationText { get; set; }
+        string OptionLabelText { get; set; }
+        bool OptionIsChecked { get; set; }
+        string CancelButtonText { get; set; }
+        string DefaultButtonText { get; set; }
+        bool HasOption { get; set; }
+        bool HasCancelButton { get; set; }
+        bool CanResize { get; set; }
+        int ClientAreaMinHeight { get; set; }
+    }
+}

--- a/Shared/Rubberduck.UI/Rubberduck.UI.csproj
+++ b/Shared/Rubberduck.UI/Rubberduck.UI.csproj
@@ -142,6 +142,7 @@
     <Compile Include="Abstract\Editor\Tools\SyncPanel\IShellToolTabProvider.cs" />
     <Compile Include="Abstract\Editor\Tools\SyncPanel\ISyncPanelModuleViewModelProvider.cs" />
     <Compile Include="Abstract\Editor\Tools\SyncPanel\ISyncPanelToolTab.cs" />
+    <Compile Include="Abstract\Editor\IDialogShellViewModel.cs" />
     <Compile Include="Command\AsyncDelegateCommand.cs" />
     <Compile Include="Command\SyncPanel\ILoadCommand.cs" />
     <Compile Include="Command\SyncPanel\IOpenCommand.cs" />


### PR DESCRIPTION
Sets up draft DialogShell user control in line with #56. Tried to make it flexible by looking ahead to the proposed designs of the message box, rename prompt and preview rename prompt. To accommodate the different layouts, the main **content** section is set as a `ContentControl` which the various specific view models can define. As an example, the design data file has a code switch to allow previewing either a text block or an input text box.

Issues:
 - Wanted to put a ScrollViewer around the TextBlock for the expandable section but was crashing in the VBE so commented out for now
 - Scaling not so nice if using a TextBox as the main control as that is the row which takes remaining space, would be fine if setting the overall dialog size appropriately

Not included is a temporary button to show the dialog in the VBE. Sample with dummy data:
<img width="352" alt="DialogShell" src="https://user-images.githubusercontent.com/4892984/235480690-3f7964d1-cde1-42a0-bd29-9c3d997bba86.png">
