### PR TITLE
Create an RD3 workspace folder structure

### DIFF
--- a/Client/Rubberduck.Client/LSP/WorkspaceInfo.cs
+++ b/Client/Rubberduck.Client/LSP/WorkspaceInfo.cs
@@ -1,0 +1,130 @@
+﻿using Rubberduck.InternalApi.Common;
+using System;
+using System.IO.Abstractions;
+
+namespace Rubberduck.Client.LSP
+{
+    /// <summary>
+    /// Provides readonly access to host document properties and
+    /// IDirectoryInfo objects for key Workspace directories.
+    /// </summary>
+    public interface IWorkspaceInfo
+    {
+        /// <summary>
+        /// Read only Absolute path to the host document of the Workspace.
+        /// </summary>
+        string HostDocumentPath { get; }
+
+        /// <summary>
+        /// The host document file name
+        /// </summary>
+        string HostDocumentName { get; }
+
+        /// <summary>
+        /// Returns an IDirectoryInfo object related to the
+        /// Rubberduck '.rd' directory.
+        /// </summary>
+        IDirectoryInfo DotRdInfo { get; }
+
+        /// <summary>
+        /// Returns an IDirectoryInfo object related to the 'Working' workspace folder.
+        /// The 'Working' folder contains unsaved file versions base on
+        /// the last exit from the RD3 editor.
+        /// </summary>
+        /// <remarks>
+        /// When the host document is saved, the 'Working' repository is cleared.
+        /// </remarks>
+        IDirectoryInfo WorkingRepoInfo { get; }
+
+        /// <summary>
+        /// Returns an IDirectoryInfo object related to the 'Saved' workspace folder.
+        /// The 'Saved' folder contains module exports from
+        /// from the last user-initiated `Save` of the host document.  
+        /// </summary>
+        IDirectoryInfo SavedRepoInfo { get; }
+    }
+
+    /// <summary>
+    /// Provides readonly access to host document properties and
+    /// IDirectoryInfo objects for Workspace directories.
+    /// </summary>
+    /// <remarks>
+    /// Initializes objects based on the host document path. It 
+    /// does not perform IO operation on the file system.
+    /// </remarks>
+    public struct WorkspaceInfo : IWorkspaceInfo
+    {
+        private const string wsFoldersName = "WorkspaceFolders";
+
+        private readonly string _hostDocumentPath;
+        private readonly IFileSystem _fileSystem;
+
+        private readonly Func<string, IDirectoryInfo> _dirInfoFactoryFunc;
+
+        /// <summary>
+        /// Creates a WorkspaceInfo struct based on the absolute path to a host document.
+        /// Other parameters should be left 'null' unless injecting a fake 
+        /// object for testing.
+        /// </summary>
+        /// <param name="hostDocumentPath">Absolute path to the host document</param>
+        /// <param name="fileSystem">Optional: should be omitted except for injecting test fakes</param>
+        /// <param name="dirInfoFunc">Optional: should be omitted except for injecting test fakes</param>
+        /// <exception cref="ArgumentNullException"></exception>
+        public WorkspaceInfo(string hostDocumentPath, 
+            IFileSystem fileSystem = null, 
+            Func<string, IDirectoryInfo> dirInfoFunc = null)
+        {
+            if (string.IsNullOrEmpty(hostDocumentPath))
+            {
+                throw new ArgumentNullException(nameof(hostDocumentPath));
+            }
+
+            _hostDocumentPath = hostDocumentPath;
+            
+            _dirInfoFactoryFunc = dirInfoFunc
+                ?? ((s) => new FileSystem().DirectoryInfo.New(s));
+
+            _fileSystem = fileSystem ?? new FileSystem();
+
+            var hostDocumentFileInfo = _fileSystem.FileInfo.New(_hostDocumentPath);
+
+            HostDocumentName = hostDocumentFileInfo.Name;
+
+            var dotRdPath = string.Join("\\", 
+                _fileSystem.Directory.GetParent(_hostDocumentPath).FullName, ".rd");
+            DotRdInfo = _dirInfoFactoryFunc(dotRdPath);
+
+            var workspaceName = hostDocumentFileInfo.Name.Replace(
+                $"{hostDocumentFileInfo.Extension}", 
+                $"_{hostDocumentFileInfo.Extension.Substring(1)}");
+
+            var workspaceDirectoryPath = string.Join("\\", DotRdInfo, workspaceName);
+            WorkspaceDirectoryInfo = _dirInfoFactoryFunc(workspaceDirectoryPath);
+
+            var savedRepoPath = string.Join("\\",
+                workspaceDirectoryPath, wsFoldersName, "saved");
+            SavedRepoInfo = _dirInfoFactoryFunc(savedRepoPath);
+
+            var workingRepoPath = string.Join("\\",
+                workspaceDirectoryPath, wsFoldersName, "working");
+            WorkingRepoInfo = _dirInfoFactoryFunc(workingRepoPath);
+        }
+
+        /// <inheritdoc/>
+        public string HostDocumentPath => _hostDocumentPath;
+
+        public string HostDocumentName { get; private set; }
+
+        /// <inheritdoc/>
+        public IDirectoryInfo DotRdInfo { get; private set; }
+
+        /// <inheritdoc/>
+        public IDirectoryInfo WorkspaceDirectoryInfo { get; private set; }
+
+        /// <inheritdoc/>
+        public IDirectoryInfo WorkingRepoInfo { get; private set; }
+
+        /// <inheritdoc/>
+        public IDirectoryInfo SavedRepoInfo { get; private set; }
+    }
+}

--- a/Client/Rubberduck.Client/LSP/WorkspaceService.cs
+++ b/Client/Rubberduck.Client/LSP/WorkspaceService.cs
@@ -1,0 +1,46 @@
+﻿using System.IO;
+using System.IO.Abstractions;
+
+namespace Rubberduck.Client.LSP
+{
+    public class WorkspaceService
+    {
+        /// <summary>
+        /// Returns an array of (string, Uri) tuples used
+        /// to create/initialize LSP WorkspaceFolder objects
+        /// </summary>
+        public static (string Name, string Uri)[] GetWorkspaceFolderTuples(
+            IWorkspaceInfo wsInfo)
+        {
+            return new (string Name, string Uri)[]
+            {
+                ($"{wsInfo.HostDocumentName}(Saved)",
+                    wsInfo.SavedRepoInfo.FullName),
+                ($"{wsInfo.HostDocumentName}(Working)",
+                    wsInfo.WorkingRepoInfo.FullName)
+            };
+        }
+
+        /// <summary>
+        /// Creates the .rd folder structure for a given host document.
+        /// If the .rd folder and path(s) already exist, the function does nothing.
+        /// </summary>
+        public static void SetupDotRdFolder(IWorkspaceInfo wsInfo)
+        {
+            if (!wsInfo.WorkingRepoInfo.Exists)
+            {
+                wsInfo.WorkingRepoInfo.Create();
+            }
+
+            if (!wsInfo.SavedRepoInfo.Exists)
+            {
+                wsInfo.SavedRepoInfo.Create();
+            }
+
+            if (wsInfo.DotRdInfo.Attributes != FileAttributes.Hidden)
+            {
+                wsInfo.DotRdInfo.Attributes = FileAttributes.Hidden;
+            }
+        }
+    }
+}

--- a/Client/Rubberduck.Client/Rubberduck.Client.csproj
+++ b/Client/Rubberduck.Client/Rubberduck.Client.csproj
@@ -133,6 +133,9 @@
     <Reference Include="System.Diagnostics.DiagnosticSource, Version=7.0.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Diagnostics.DiagnosticSource.7.0.1\lib\net462\System.Diagnostics.DiagnosticSource.dll</HintPath>
     </Reference>
+    <Reference Include="System.IO.Abstractions, Version=19.0.0.0, Culture=neutral, PublicKeyToken=96bf224d23c43e59, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.IO.Abstractions.19.1.18\lib\net461\System.IO.Abstractions.dll</HintPath>
+    </Reference>
     <Reference Include="System.IO.Compression" />
     <Reference Include="System.IO.Pipelines, Version=7.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.IO.Pipelines.7.0.0\lib\net462\System.IO.Pipelines.dll</HintPath>
@@ -184,10 +187,18 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
+    <Reference Include="TestableIO.System.IO.Abstractions, Version=19.0.0.0, Culture=neutral, PublicKeyToken=96bf224d23c43e59, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\TestableIO.System.IO.Abstractions.19.1.18\lib\net461\TestableIO.System.IO.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="TestableIO.System.IO.Abstractions.Wrappers, Version=19.0.0.0, Culture=neutral, PublicKeyToken=96bf224d23c43e59, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\TestableIO.System.IO.Abstractions.Wrappers.19.1.18\lib\net461\TestableIO.System.IO.Abstractions.Wrappers.dll</HintPath>
+    </Reference>
     <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="LSP\LspClientService.cs" />
+    <Compile Include="LSP\WorkspaceInfo.cs" />
+    <Compile Include="LSP\WorkspaceService.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Client/Rubberduck.Client/packages.config
+++ b/Client/Rubberduck.Client/packages.config
@@ -35,6 +35,7 @@
   <package id="System.Buffers" version="4.5.1" targetFramework="net48" />
   <package id="System.Collections.Immutable" version="7.0.0" targetFramework="net48" />
   <package id="System.Diagnostics.DiagnosticSource" version="7.0.1" targetFramework="net48" />
+  <package id="System.IO.Abstractions" version="19.1.18" targetFramework="net48" />
   <package id="System.IO.Pipelines" version="7.0.0" targetFramework="net48" />
   <package id="System.Memory" version="4.5.5" targetFramework="net48" />
   <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net48" />
@@ -50,4 +51,6 @@
   <package id="System.Threading.Tasks.Dataflow" version="7.0.0" targetFramework="net48" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net48" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net48" />
+  <package id="TestableIO.System.IO.Abstractions" version="19.1.18" targetFramework="net48" />
+  <package id="TestableIO.System.IO.Abstractions.Wrappers" version="19.1.18" targetFramework="net48" />
 </packages>

--- a/Tests/Rubberduck.Tests/Rubberduck.Tests.csproj
+++ b/Tests/Rubberduck.Tests/Rubberduck.Tests.csproj
@@ -18,6 +18,9 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="TestableIO.System.IO.Abstractions" Version="19.1.18" />
+    <PackageReference Include="TestableIO.System.IO.Abstractions.TestingHelpers" Version="19.1.18" />
+    <PackageReference Include="TestableIO.System.IO.Abstractions.Wrappers" Version="19.1.18" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
@@ -26,6 +29,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\Client\Rubberduck.Client\Rubberduck.Client.csproj" />
     <ProjectReference Include="..\..\Shared\Rubberduck.UI\Rubberduck.UI.csproj" />
     <ProjectReference Include="..\..\Client\Rubberduck.VBEditor\Rubberduck.VBEditor.csproj" />
   </ItemGroup>

--- a/Tests/Rubberduck.Tests/Workspace/SetupDotRdFolderTests.cs
+++ b/Tests/Rubberduck.Tests/Workspace/SetupDotRdFolderTests.cs
@@ -1,0 +1,78 @@
+using Moq;
+using System.IO.Abstractions;
+//using Rubberduck.Server.Workspace;
+using Rubberduck.Tests.Workspace;
+using Rubberduck.Client.LSP;
+
+namespace Rubberduck.Tests.WorkspaceServiceTests
+{
+    public class SetupDotRdFolderTests
+    { 
+        [Theory]
+        [InlineData(false, false, 1, 1)]
+        [InlineData(true, true, 0, 0)]
+        [InlineData(false, true, 1, 0)]
+        [InlineData(true, false, 0, 1)]
+        public void SetupDotRdFolder_WorkspaceFolderDoesNotExist_CreatesFolders(
+            bool workingExists, bool savedExists,
+            int expectedCreateWorking, int expectedCreateSaved)
+        {
+            //Arrange
+            var hostDoc = @"C:\users\duck\MyProjects\TestExcel\TestExcel.xlsm";
+
+            var mockWorkspaceInfo 
+                = WorkspaceTestsSupport.GetWorkspaceInfoFake(hostDoc);
+            Mock.Get(mockWorkspaceInfo.WorkingRepoInfo).Setup<bool>(di => di.Exists)
+                .Returns(workingExists);
+            Mock.Get(mockWorkspaceInfo.SavedRepoInfo).Setup<bool>(di => di.Exists)
+                .Returns(savedExists);
+
+            //Act
+            WorkspaceService.SetupDotRdFolder(mockWorkspaceInfo);
+
+            //Assert
+            Mock.Get(mockWorkspaceInfo.WorkingRepoInfo).Verify(wr => wr.Create(), 
+                Times.Exactly(expectedCreateWorking));
+
+            Mock.Get(mockWorkspaceInfo.SavedRepoInfo).Verify(wr => wr.Create(), 
+                Times.Exactly(expectedCreateSaved));
+        }
+
+        [Fact]
+        public void SetupDotRdFolder_WorkspaceFolderExists()
+        {
+            //Arrange
+            var hostDoc = @"C:\users\duck\MyProjects\TestExcel\TestExcel.xlsm";
+
+            var mockWorkspaceInfo
+                = WorkspaceTestsSupport.GetWorkspaceInfoFake(hostDoc, true);
+
+            //Act
+            WorkspaceService.SetupDotRdFolder(mockWorkspaceInfo);
+
+            //Assert
+            Mock.Get(mockWorkspaceInfo.WorkingRepoInfo)
+                .Verify(wri => wri.Create(), Times.Never);
+
+            Mock.Get(mockWorkspaceInfo.SavedRepoInfo)
+                .Verify(wri => wri.Create(), Times.Never);
+        }
+
+        [Fact]
+        public void SetupDotRdFolder_DotRdFolderIsHidden()
+        {
+            //Arrange
+            var hostDoc = @"C:\users\duck\MyProjects\TestExcel\TestExcel.xlsm";
+
+            var mockWorkspaceInfo
+                = WorkspaceTestsSupport.GetWorkspaceInfoFake(hostDoc);
+
+            //Act
+            WorkspaceService.SetupDotRdFolder(mockWorkspaceInfo);
+
+            //Assert
+            Assert.True(mockWorkspaceInfo
+                .DotRdInfo.Attributes.HasFlag(FileAttributes.Hidden));
+        }
+    }
+}

--- a/Tests/Rubberduck.Tests/Workspace/WorkspaceServiceTests.cs
+++ b/Tests/Rubberduck.Tests/Workspace/WorkspaceServiceTests.cs
@@ -1,0 +1,34 @@
+﻿using Moq;
+using Rubberduck.Client.LSP;
+using Rubberduck.Tests.Workspace;
+using System.IO.Abstractions;
+
+namespace Rubberduck.Tests.WorkspaceServiceTests
+{
+    public class WorkspaceServiceTests
+    {
+        [Theory]
+        [InlineData(0, "TestExcel.xlsm(Saved)", 
+            @"C:\users\duck\MyProjects\TestExcel\.rd\TestExcel_xlsm\WorkspaceFolders\saved")]
+        [InlineData(1, "TestExcel.xlsm(Working)",
+            @"C:\users\duck\MyProjects\TestExcel\.rd\TestExcel_xlsm\WorkspaceFolders\working")]
+        public void TestGetWorkspaceFolderTuples(int wsFoldersIndex, 
+            string expectedName, 
+            string expectedUri)
+        {
+            //Arrange
+            var hostDocPath =
+                @"C:\users\duck\MyProjects\TestExcel\TestExcel.xlsm";
+            
+            var wsInfoStub = WorkspaceTestsSupport.GetWorkspaceInfoFake(hostDocPath);
+
+            //Act
+            var wsFolders = WorkspaceService.GetWorkspaceFolderTuples(wsInfoStub);
+
+            //Assert
+            Assert.Equal(2, wsFolders.Length);
+            Assert.Equal(expectedName, wsFolders[wsFoldersIndex].Name);
+            Assert.Equal(expectedUri, wsFolders[wsFoldersIndex].Uri);
+        }
+    }
+}

--- a/Tests/Rubberduck.Tests/Workspace/WorkspaceTestsSupport.cs
+++ b/Tests/Rubberduck.Tests/Workspace/WorkspaceTestsSupport.cs
@@ -1,0 +1,42 @@
+﻿using Moq;
+using Rubberduck.Client.LSP;
+using System.IO.Abstractions;
+
+namespace Rubberduck.Tests.Workspace
+{
+    public class WorkspaceTestsSupport
+    {
+        public static IWorkspaceInfo GetWorkspaceInfoFake(
+            string hostDocPath, bool allPathsExist = false)
+        {
+            var wsInfoReal = new WorkspaceInfo(hostDocPath);
+
+            var wsInfoFake = new WorkspaceInfo(hostDocPath, 
+                dirInfoFunc: (s) => Mock.Of<IDirectoryInfo>());
+
+            var directoryInfoPairs
+                = new (IDirectoryInfo fake, IDirectoryInfo real)[]
+                {
+                    (wsInfoFake.DotRdInfo, wsInfoReal.DotRdInfo),
+                    (wsInfoFake.WorkspaceDirectoryInfo,
+                        wsInfoReal.WorkspaceDirectoryInfo),
+                    (wsInfoFake.WorkingRepoInfo, wsInfoReal.WorkingRepoInfo),
+                    (wsInfoFake.SavedRepoInfo, wsInfoReal.SavedRepoInfo)
+                };
+
+            foreach (var (fake, real) in directoryInfoPairs)
+            {
+                Mock.Get(fake).Setup<string>(di => di.Name)
+                   .Returns(real.Name);
+
+                Mock.Get(fake).Setup<string>(di => di.FullName)
+                   .Returns(real.FullName);
+
+                Mock.Get(fake).Setup<bool>(di => di.Exists)
+                    .Returns(allPathsExist);
+            }
+
+            return wsInfoFake as IWorkspaceInfo;
+        }
+    }
+}


### PR DESCRIPTION
Related to #25 

Contains classes and functions to setup the `.rd` folder structure for RD3 based on #37 discussion.

Calling `WorkspaceService.SetupDotRdFolder(...)` for an Excel host document located at `C:\MyExcelStuff\KillerApp.xlsm` results in creating the following folder structure:

`C:\MyExcelStuff\.rd\KillerApp_xlsm\WorkspaceFolders\Saved`
`C:\MyExcelStuff\.rd\KillerApp_xlsm\WorkspaceFolders\Working`

There are two classes:
1. `WorkspaceInfo.cs` defining an `IWorkspaceInfo` interface that exposes readonly host document properties and `IDirectoryInfo` objects related to key `Workspace` folders.

2. `WorkspaceService.cs` contains a function to create the `Workspace` file system and a function that _almost_ creates a `WorkspaceFolder[]`:

- `public static void SetupDotRdFolder(IWorkspaceInfo wsInfo)` and,
- `public static (string Name, string Uri)[] GetWorkspaceFolderTuples(IWorkspaceInfo wsInfo)`
  
`GetWorkspaceFolderTuples(IWorkspaceInfo wsInfo)` returns a `(string, string)[]` rather than a `WorkspaceFolder[]`.  This is because (AFAICT) the only option to create a `OmniSharp.Extensions.LanguageServer.Protocol.Models.WorkspaceFolder` is code of this form:
```
	new WorkspaceFolder()
	{
		Name = $"{wsInfo.HostDocumentName}(Saved)",
		Uri = <DocumentUri created from wsInfo.SavedRepoInfo.FullName>
	},
```
This creation/initialization scheme requires C# 9.0 or greater because the `WorkspaceFolder.Name` property is defined as 
`public string Name { get; init; } = null!;`  which uses an 'init-only' setter. (Same is true for `WorkspaceFolder.Uri`).  Using C# 9.0 looks like it requires .Net 5.

Since I could not find a way to overcome this, I thought submitting this as a draft PR would be a better way to describe the issue to get some comments/help.

For now, the `WorkspaceService` functions are all `public static` though I expect the declarations should change when the classes/functions are integrated into the `Initialize` process.  Also, since the `Client` orchestrates the initialization process (AIUI), the classes are located in the `Rubberduck.Client.LSP` project - they may belong elsewhere.

