### PR TITLE
Collect some state

### DIFF
--- a/Client/Rubberduck.Unmanaged/Rubberduck.Unmanaged.csproj
+++ b/Client/Rubberduck.Unmanaged/Rubberduck.Unmanaged.csproj
@@ -8,6 +8,7 @@
     <Nullable>disable</Nullable>
     <Platforms>AnyCPU</Platforms>
     <PlatformTarget>AnyCPU</PlatformTarget>
+    <EmbedManifest>True</EmbedManifest>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Server/Rubberduck.LanguageServer/Handlers/Language/DocumentSymbolHandler.cs
+++ b/Server/Rubberduck.LanguageServer/Handlers/Language/DocumentSymbolHandler.cs
@@ -2,7 +2,11 @@
 using OmniSharp.Extensions.LanguageServer.Protocol.Document;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using OmniSharp.Extensions.LanguageServer.Protocol.Server;
+using Rubberduck.InternalApi.Extensions;
 using Rubberduck.InternalApi.ServerPlatform.LanguageServer;
+using Rubberduck.InternalApi.Services;
+using Rubberduck.ServerPlatform;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -12,24 +16,15 @@ namespace Rubberduck.LanguageServer.Handlers.Language
 {
     public class DocumentSymbolHandler : DocumentSymbolHandlerBase
     {
-        private readonly ILanguageServerFacade _server;
-        private readonly SupportedLanguage _language;
-        private readonly DocumentContentStore _contentStore;
-
+        private readonly ServerPlatformServiceHelper _service;
+        private readonly IWorkspaceStateManager _workspaces;
         private readonly TextDocumentSelector _selector;
 
-        public DocumentSymbolHandler(ILanguageServerFacade server, SupportedLanguage language, DocumentContentStore contentStore)
+        public DocumentSymbolHandler(ServerPlatformServiceHelper service, IWorkspaceStateManager workspaces, SupportedLanguage language)
         {
-            _language = language;
-            _server = server;
-            _contentStore = contentStore;
-
-            var filter = new TextDocumentFilter
-            {
-                Language = language.Id,
-                Pattern = string.Join(";", language.FileTypes.Select(fileType => $"**/{fileType}").ToArray())
-            };
-            _selector = new TextDocumentSelector(filter);
+            _service = service;
+            _workspaces = workspaces;
+            _selector = language.ToTextDocumentSelector();
         }
 
         public async override Task<SymbolInformationOrDocumentSymbolContainer?> Handle(DocumentSymbolParams request, CancellationToken cancellationToken)
@@ -37,7 +32,28 @@ namespace Rubberduck.LanguageServer.Handlers.Language
             cancellationToken.ThrowIfCancellationRequested();
 
             var items = new List<SymbolInformationOrDocumentSymbol>();
-            // TODO
+            
+            if (!_service.TryRunAction(() =>
+            {
+                var documentUri = request.TextDocument.Uri;
+                var workspace = _workspaces.ActiveWorkspace
+                    ?? throw new InvalidOperationException("Invalid WorkspaceStateManager state: there is no active workspace.");
+
+                var uri = new WorkspaceFileUri(documentUri.ToUri().OriginalString, workspace.WorkspaceRoot!.WorkspaceRoot);
+                if (workspace.TryGetWorkspaceFile(uri, out var document) && document?.Symbol != null)
+                {
+                    items.Add(new SymbolInformationOrDocumentSymbol(document.Symbol));
+                    _service.LogInformation($"Found symbol ({document.Symbol.GetType().Name}: {document.Symbol.Children!.Count()} children) for document at uri '{uri}'.");
+                }
+                else
+                {
+                    _service.LogWarning($"Could not find workspace file at uri '{uri}'. An empty collection will be returned.");
+                }
+            }, out var exception, nameof(DocumentSymbolHandler)) && exception != null)
+            {
+                // in case of failure, we throw here to return an error response:
+                throw exception;
+            }
 
             var result = new SymbolInformationOrDocumentSymbolContainer(items);
             return await Task.FromResult(result);

--- a/Server/Rubberduck.LanguageServer/LanguageServerState.cs
+++ b/Server/Rubberduck.LanguageServer/LanguageServerState.cs
@@ -11,6 +11,8 @@ using System.Threading;
 
 namespace Rubberduck.LanguageServer
 {
+
+
     public interface ILanguageServerState : IServerStateWriter
     {
         DocumentUri? RootUri { get; set; }

--- a/Server/Rubberduck.LanguageServer/ServerApp.cs
+++ b/Server/Rubberduck.LanguageServer/ServerApp.cs
@@ -68,35 +68,11 @@ namespace Rubberduck.LanguageServer
             }
         }
 
-        //private TextDocumentSelector GetSelector(SupportedLanguage language)
-        //{
-        //    var filter = new TextDocumentFilter
-        //    {
-        //        Language = language.Id,
-        //        Pattern = string.Join(";", language.FileTypes.Select(fileType => $"**/{fileType}").ToArray())
-        //    };
-        //    return new TextDocumentSelector(filter);
-        //}
-
-        //private void HandleDidOpenTextDocument(DidOpenTextDocumentParams request, TextSynchronizationCapability capability, CancellationToken token)
-        //{
-        //    _logger?.LogDebug("Received DidOpenTextDocument notification.");
-        //}
-
-        //private TextDocumentOpenRegistrationOptions GetTextDocumentOpenRegistrationOptions(TextSynchronizationCapability capability, ClientCapabilities clientCapabilities)
-        //{
-        //    return new TextDocumentOpenRegistrationOptions
-        //    {
-        //        DocumentSelector = GetSelector(new VisualBasicForApplicationsLanguage())
-        //    };
-        //}
-
         protected override ServerState<LanguageServerSettings, LanguageServerStartupSettings> GetServerState(IServiceProvider provider) 
             => provider.GetRequiredService<LanguageServerState>();
 
         protected override void ConfigureServices(ServerStartupOptions options, IServiceCollection services)
         {
-            //services.AddSingleton<ILanguageServerFacade>(provider => _languageServer);
             services.AddSingleton<ServerStartupOptions>(provider => options);
 
             if (options.ClientProcessId > 0)

--- a/Server/Rubberduck.LanguageServer/ServerApp.cs
+++ b/Server/Rubberduck.LanguageServer/ServerApp.cs
@@ -5,6 +5,7 @@ using OmniSharp.Extensions.LanguageServer.Protocol.Server;
 using OmniSharp.Extensions.LanguageServer.Protocol.Server.WorkDone;
 using OmniSharp.Extensions.LanguageServer.Server;
 using Rubberduck.InternalApi.Extensions;
+using Rubberduck.InternalApi.Model.Declarations.Execution;
 using Rubberduck.InternalApi.ServerPlatform.LanguageServer;
 using Rubberduck.InternalApi.Services;
 using Rubberduck.InternalApi.Settings;
@@ -16,6 +17,8 @@ using Rubberduck.LanguageServer.Handlers.Workspace;
 using Rubberduck.Parsing._v3.Pipeline;
 using Rubberduck.Parsing._v3.Pipeline.Services;
 using Rubberduck.Parsing.Abstract;
+using Rubberduck.Parsing.COM.Abstract;
+using Rubberduck.Parsing.Model.ComReflection;
 using Rubberduck.Parsing.Parsers;
 using Rubberduck.Parsing.PreProcessing;
 using Rubberduck.Parsing.TokenStreamProviders;
@@ -109,6 +112,8 @@ namespace Rubberduck.LanguageServer
             services.AddSingleton<IWorkspaceStateManager, WorkspaceStateManager>();
 
             services.AddSingleton<WorkspacePipeline>();
+            services.AddSingleton<LibrarySymbolsService>();
+            services.AddSingleton<IComLibraryProvider, ComLibraryProvider>();
             services.AddSingleton<ParserPipelineSectionProvider>();
             services.AddTransient<WorkspaceDocumentParserOrchestrator>();
             services.AddTransient<DocumentParserSection>();

--- a/Server/Rubberduck.LanguageServer/ServerApp.cs
+++ b/Server/Rubberduck.LanguageServer/ServerApp.cs
@@ -62,6 +62,9 @@ namespace Rubberduck.LanguageServer
 
                 await task;
                 logger.LogInformation($"Workspace was processed: {task.Status}");
+
+                var workspace = app.State.ActiveWorkspace!;
+                logger.LogInformation($"{workspace.ExecutionContext.UnresolvedSymbols.Count} unresolved symbols.");
             }
         }
 

--- a/Server/Rubberduck.LanguageServer/ServerApp.cs
+++ b/Server/Rubberduck.LanguageServer/ServerApp.cs
@@ -18,6 +18,7 @@ using Rubberduck.Parsing._v3.Pipeline;
 using Rubberduck.Parsing._v3.Pipeline.Services;
 using Rubberduck.Parsing.Abstract;
 using Rubberduck.Parsing.COM.Abstract;
+using Rubberduck.Parsing.Exceptions;
 using Rubberduck.Parsing.Model.ComReflection;
 using Rubberduck.Parsing.Parsers;
 using Rubberduck.Parsing.PreProcessing;
@@ -110,7 +111,7 @@ namespace Rubberduck.LanguageServer
 
             services.AddSingleton<IWorkspaceService, WorkspaceService>();
             services.AddSingleton<IWorkspaceStateManager, WorkspaceStateManager>();
-
+            services.AddSingleton<ISyntaxErrorMessageService, SyntaxErrorMessageService>();
             services.AddSingleton<WorkspacePipeline>();
             services.AddSingleton<LibrarySymbolsService>();
             services.AddSingleton<IComLibraryProvider, ComLibraryProvider>();

--- a/Server/Rubberduck.LanguageServer/ServerApp.cs
+++ b/Server/Rubberduck.LanguageServer/ServerApp.cs
@@ -12,6 +12,7 @@ using Rubberduck.InternalApi.Settings;
 using Rubberduck.InternalApi.Settings.Model;
 using Rubberduck.InternalApi.Settings.Model.LanguageClient;
 using Rubberduck.InternalApi.Settings.Model.LanguageServer;
+using Rubberduck.LanguageServer.Handlers.Language;
 using Rubberduck.LanguageServer.Handlers.Lifecycle;
 using Rubberduck.LanguageServer.Handlers.Workspace;
 using Rubberduck.Parsing._v3.Pipeline;
@@ -66,6 +67,8 @@ namespace Rubberduck.LanguageServer
                 var workspace = app.State.ActiveWorkspace!;
                 logger.LogInformation($"{workspace.ExecutionContext.UnresolvedSymbols.Count} unresolved symbols.");
             }
+
+            await Task.Delay(100);
         }
 
         protected override ServerState<LanguageServerSettings, LanguageServerStartupSettings> GetServerState(IServiceProvider provider) 
@@ -167,8 +170,10 @@ namespace Rubberduck.LanguageServer
                 .WithHandler<DocumentHighlightHandler>()
                 .WithHandler<DocumentOnTypeFormattingHandler>()
                 .WithHandler<DocumentRangeFormattingHandler>()
+            */
                 .WithHandler<DocumentSymbolHandler>()
                 .WithHandler<FoldingRangeHandler>()
+            /*
                 .WithHandler<HoverHandler>()
                 .WithHandler<ImplementationHandler>()
                 .WithHandler<PrepareRenameHandler>()

--- a/Server/Rubberduck.LanguageServer/ServerApp.cs
+++ b/Server/Rubberduck.LanguageServer/ServerApp.cs
@@ -230,6 +230,10 @@ namespace Rubberduck.LanguageServer
 
                 service.LogInformation($"Project {pipeline.State.ProjectName} ({pipeline.State.WorkspaceFiles.Count()} files) is good to go!");
             }
+            else
+            {
+                service.LogWarning("Workspace was not loaded.", "IWorkspaceService.OpenProjectWorkspaceAsync(Uri) returned false.");
+            }
         }
     }
 }

--- a/Server/Rubberduck.LanguageServer/SyntaxErrorMessageService.cs
+++ b/Server/Rubberduck.LanguageServer/SyntaxErrorMessageService.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.Extensions.Logging;
+using Rubberduck.InternalApi.Services;
+using Rubberduck.InternalApi.Settings;
+using Rubberduck.Parsing.Exceptions;
+
+namespace Rubberduck.LanguageServer
+{
+    public class SyntaxErrorMessageService : ServiceBase, ISyntaxErrorMessageService
+    {
+        public SyntaxErrorMessageService(ILogger<SyntaxErrorMessageService> logger, RubberduckSettingsProvider settingsProvider, PerformanceRecordAggregator performance) 
+            : base(logger, settingsProvider, performance)
+        {
+        }
+
+        public bool TryGetMeaningfulMessage(AntlrSyntaxErrorInfo info, out string message)
+        {
+            /*TODO*/
+
+            message = info.Message;
+            return false;
+        }
+    }
+}

--- a/Server/Rubberduck.Parsing/Abstract/ICompilationArgumentsCache.cs
+++ b/Server/Rubberduck.Parsing/Abstract/ICompilationArgumentsCache.cs
@@ -1,9 +1,11 @@
-﻿namespace Rubberduck.Parsing.Abstract;
+﻿using Rubberduck.InternalApi.Extensions;
+
+namespace Rubberduck.Parsing.Abstract;
 
 public interface ICompilationArgumentsCache : ICompilationArgumentsProvider
 {
-    void ReloadCompilationArguments(IEnumerable<Uri> workspaceUris);
-    IReadOnlyCollection<Uri> ProjectWhoseCompilationArgumentsChanged();
+    void ReloadCompilationArguments(IEnumerable<WorkspaceUri> workspaceUris);
+    IReadOnlyCollection<WorkspaceUri> ProjectWhoseCompilationArgumentsChanged();
     void ClearProjectWhoseCompilationArgumentsChanged();
-    void RemoveCompilationArgumentsFromCache(IEnumerable<Uri> workspaceUris);
+    void RemoveCompilationArgumentsFromCache(IEnumerable<WorkspaceUri> workspaceUris);
 }

--- a/Server/Rubberduck.Parsing/Abstract/ICompilationArgumentsProvider.cs
+++ b/Server/Rubberduck.Parsing/Abstract/ICompilationArgumentsProvider.cs
@@ -1,9 +1,10 @@
-﻿using Rubberduck.Parsing.PreProcessing;
+﻿using Rubberduck.InternalApi.Extensions;
+using Rubberduck.Parsing.PreProcessing;
 
 namespace Rubberduck.Parsing.Abstract;
 
 public interface ICompilationArgumentsProvider
 {
     VBAPredefinedCompilationConstants PredefinedCompilationConstants { get; }
-    Dictionary<string, short> UserDefinedCompilationArguments(Uri workspaceRoot);
+    Dictionary<string, short> UserDefinedCompilationArguments(WorkspaceUri workspaceRoot);
 }

--- a/Server/Rubberduck.Parsing/Abstract/IParser.cs
+++ b/Server/Rubberduck.Parsing/Abstract/IParser.cs
@@ -15,7 +15,7 @@ public class ParseResult
 
 public interface IParser<TContent>
 {
-    ParseResult Parse(WorkspaceFileUri uri, TContent content, CancellationToken token, CodeKind codeKind = CodeKind.RubberduckEditorModule, ParserMode parserMode = ParserMode.FallBackSllToLl, IEnumerable<IParseTreeListener>? parseListeners = null);
+    ParseResult Parse(WorkspaceFileUri uri, TContent content, CancellationToken token, ParserMode parserMode = ParserMode.FallBackSllToLl, IEnumerable<IParseTreeListener>? parseListeners = null);
 }
 
 public interface IStringParser : IParser<string> { }

--- a/Server/Rubberduck.Parsing/Abstract/IParser.cs
+++ b/Server/Rubberduck.Parsing/Abstract/IParser.cs
@@ -11,6 +11,7 @@ public class ParseResult
     public ITokenStream TokenStream { get; init; } = null!;
     public LogicalLineStore? LogicalLines { get; init; } = null;
     public IEnumerable<IParseTreeListener> Listeners { get; init; } = [];
+    public IEnumerable<SyntaxErrorInfo> SyntaxErrors { get; init; } = [];
 }
 
 public interface IParser<TContent>

--- a/Server/Rubberduck.Parsing/Abstract/ITokenStreamParser.cs
+++ b/Server/Rubberduck.Parsing/Abstract/ITokenStreamParser.cs
@@ -1,11 +1,10 @@
 ﻿using Antlr4.Runtime;
 using Antlr4.Runtime.Tree;
 using Rubberduck.InternalApi.Extensions;
-using Rubberduck.Parsing.Model;
 
 namespace Rubberduck.Parsing.Abstract;
 
 public interface ITokenStreamParser
 {
-    IParseTree Parse(WorkspaceFileUri uri, CommonTokenStream tokenStream, CancellationToken token, CodeKind codeKind = CodeKind.RubberduckEditorModule, ParserMode parserMode = ParserMode.FallBackSllToLl, IEnumerable<IParseTreeListener>? parseListeners = null);
+    IParseTree Parse(WorkspaceFileUri uri, CommonTokenStream tokenStream, CancellationToken token, ParserMode parserMode = ParserMode.FallBackSllToLl, IEnumerable<IParseTreeListener>? parseListeners = null);
 }

--- a/Server/Rubberduck.Parsing/Abstract/ITokenStreamParser.cs
+++ b/Server/Rubberduck.Parsing/Abstract/ITokenStreamParser.cs
@@ -1,10 +1,11 @@
 ﻿using Antlr4.Runtime;
 using Antlr4.Runtime.Tree;
 using Rubberduck.InternalApi.Extensions;
+using Rubberduck.Parsing.Model;
 
 namespace Rubberduck.Parsing.Abstract;
 
 public interface ITokenStreamParser
 {
-    IParseTree Parse(WorkspaceFileUri uri, CommonTokenStream tokenStream, CancellationToken token, ParserMode parserMode = ParserMode.FallBackSllToLl, IEnumerable<IParseTreeListener>? parseListeners = null);
+    IParseTree Parse(WorkspaceFileUri uri, CommonTokenStream tokenStream, CancellationToken token, out IEnumerable<SyntaxErrorInfo> errors, ParserMode parserMode = ParserMode.FallBackSllToLl, IEnumerable<IParseTreeListener>? parseListeners = null);
 }

--- a/Server/Rubberduck.Parsing/Abstract/ITokenStreamPreprocessor.cs
+++ b/Server/Rubberduck.Parsing/Abstract/ITokenStreamPreprocessor.cs
@@ -6,5 +6,5 @@ namespace Rubberduck.Parsing.Abstract;
 
 public interface ITokenStreamPreprocessor
 {
-    CommonTokenStream? PreprocessTokenStream(WorkspaceFileUri uri, CommonTokenStream tokenStream, CancellationToken token, CodeKind codeKind = CodeKind.SnippetCode);
+    CommonTokenStream? PreprocessTokenStream(WorkspaceFileUri uri, CommonTokenStream tokenStream, CancellationToken token);
 }

--- a/Server/Rubberduck.Parsing/Exceptions/AntlrSyntaxErrorInfo.cs
+++ b/Server/Rubberduck.Parsing/Exceptions/AntlrSyntaxErrorInfo.cs
@@ -8,7 +8,6 @@ namespace Rubberduck.Parsing.Exceptions;
 public record class AntlrSyntaxErrorInfo
 {
     public WorkspaceFileUri Uri { get; init; } = default!;
-    public CodeKind CodeKind { get; init; }
 
     public string Message { get; init; } = default!;
 

--- a/Server/Rubberduck.Parsing/Exceptions/ReportingSyntaxErrorListener.cs
+++ b/Server/Rubberduck.Parsing/Exceptions/ReportingSyntaxErrorListener.cs
@@ -1,6 +1,5 @@
 ﻿using Antlr4.Runtime;
 using Rubberduck.InternalApi.Extensions;
-using Rubberduck.Parsing.Model;
 
 namespace Rubberduck.Parsing.Exceptions;
 

--- a/Server/Rubberduck.Parsing/Exceptions/ReportingSyntaxErrorListener.cs
+++ b/Server/Rubberduck.Parsing/Exceptions/ReportingSyntaxErrorListener.cs
@@ -6,24 +6,7 @@ namespace Rubberduck.Parsing.Exceptions;
 
 public class ReportingSyntaxErrorListener : RubberduckParseErrorListenerBase
 {
-    public ReportingSyntaxErrorListener(WorkspaceFileUri uri, CodeKind codeKind) :base(uri, codeKind) { }
+    public ReportingSyntaxErrorListener(WorkspaceFileUri uri, ISyntaxErrorMessageService messageService) :base(uri, messageService) { }
 
-    public List<AntlrSyntaxErrorInfo> SyntaxErrors { get; } = [];
-
-    public override void SyntaxError(IRecognizer recognizer, IToken offendingSymbol, int line, int charPositionInLine, string msg, RecognitionException e)
-    {
-        SyntaxErrors.Add(
-            new AntlrSyntaxErrorInfo
-            {
-                Uri = this.Uri,
-                CodeKind = this.CodeKind,
-
-                Message = msg, // TODO implement a service dedicated to figuring out syntax error messages; ideally ANTLR error messages never reach the editor.
-                Exception = e,
-                OffendingSymbol = offendingSymbol,
-
-                LineNumber = line,
-                Position = charPositionInLine,
-            });
-    }
+    protected override List<AntlrSyntaxErrorInfo> Errors { get; } = [];
 }

--- a/Server/Rubberduck.Parsing/Exceptions/RubberduckParseErrorListenerBase.cs
+++ b/Server/Rubberduck.Parsing/Exceptions/RubberduckParseErrorListenerBase.cs
@@ -1,18 +1,51 @@
 ﻿using Antlr4.Runtime;
 using Rubberduck.InternalApi.Extensions;
 using Rubberduck.Parsing.Abstract;
-using Rubberduck.Parsing.Model;
+using System.Collections.Immutable;
 
 namespace Rubberduck.Parsing.Exceptions;
 
-public class RubberduckParseErrorListenerBase : BaseErrorListener, IRubberduckParseErrorListener
+public interface ISyntaxErrorMessageService
 {
-    public RubberduckParseErrorListenerBase(WorkspaceFileUri uri, CodeKind codeKind)
+    bool TryGetMeaningfulMessage(AntlrSyntaxErrorInfo info, out string message);
+}
+
+public abstract class RubberduckParseErrorListenerBase : BaseErrorListener, IRubberduckParseErrorListener
+{
+    private readonly ISyntaxErrorMessageService? _errorMessageService;
+
+    public RubberduckParseErrorListenerBase(WorkspaceFileUri uri, ISyntaxErrorMessageService? messageService)
     {
         Uri = uri;
-        CodeKind = codeKind;
+        _errorMessageService = messageService;
     }
 
     protected WorkspaceFileUri Uri { get; }
-    protected CodeKind CodeKind { get; }
- }
+
+    public ImmutableArray<AntlrSyntaxErrorInfo> SyntaxErrors => Errors.ToImmutableArray();
+
+    protected abstract List<AntlrSyntaxErrorInfo> Errors { get; }
+
+    protected virtual AntlrSyntaxErrorInfo GetErrorInfo(IToken offendingSymbol, int line, int charPositionInLine, string msg, RecognitionException e) => new()
+    {
+        Uri = this.Uri,
+
+        Message = msg,
+        Exception = e,
+        OffendingSymbol = offendingSymbol,
+
+        LineNumber = line,
+        Position = charPositionInLine,
+    };
+
+
+    public override void SyntaxError(IRecognizer recognizer, IToken offendingSymbol, int line, int charPositionInLine, string msg, RecognitionException e)
+    {
+        var info = GetErrorInfo(offendingSymbol, line, charPositionInLine, msg, e);
+        if (_errorMessageService != null && _errorMessageService.TryGetMeaningfulMessage(info, out var message))
+        {
+            info = info with { Message = message };
+        }
+        Errors.Add(info);
+    }
+}

--- a/Server/Rubberduck.Parsing/Exceptions/SyntaxErrorException.cs
+++ b/Server/Rubberduck.Parsing/Exceptions/SyntaxErrorException.cs
@@ -12,9 +12,9 @@ namespace Rubberduck.Parsing.Exceptions;
 public class SyntaxErrorException : Exception
 {
     public SyntaxErrorException(AntlrSyntaxErrorInfo info)
-        : this(info.Uri, info.Message, info.Exception, info.OffendingSymbol, info.LineNumber, info.Position, info.CodeKind) { }
+        : this(info.Uri, info.Message, info.Exception, info.OffendingSymbol, info.LineNumber, info.Position) { }
 
-    public SyntaxErrorException(WorkspaceFileUri uri, string message, RecognitionException innerException, IToken offendingSymbol, int line, int position, CodeKind codeKind)
+    public SyntaxErrorException(WorkspaceFileUri uri, string message, RecognitionException innerException, IToken offendingSymbol, int line, int position)
         : base(message, innerException)
     {
         Uri = uri;
@@ -22,8 +22,6 @@ public class SyntaxErrorException : Exception
         OffendingSymbol = offendingSymbol;
         LineNumber = line;
         Position = position;
-
-        CodeKind = codeKind;
     }
 
     public WorkspaceFileUri Uri { get; init; }
@@ -31,8 +29,6 @@ public class SyntaxErrorException : Exception
     public IToken OffendingSymbol { get; init; }
     public int LineNumber { get; init; }
     public int Position { get; init; }
-
-    public CodeKind CodeKind { get; init; } // still needed?
 
     public override string ToString() => $"{base.ToString()}\nToken: {OffendingSymbol.Text} at L{LineNumber}C{Position}";
 }

--- a/Server/Rubberduck.Parsing/Exceptions/SyntaxErrorNotificationListener.cs
+++ b/Server/Rubberduck.Parsing/Exceptions/SyntaxErrorNotificationListener.cs
@@ -1,6 +1,7 @@
 ﻿using Antlr4.Runtime;
 using Rubberduck.InternalApi.Extensions;
 using Rubberduck.Parsing.Model;
+using System.Collections.Immutable;
 
 namespace Rubberduck.Parsing.Exceptions;
 
@@ -8,24 +9,14 @@ public class SyntaxErrorNotificationListener : RubberduckParseErrorListenerBase
 {
     private readonly IList<AntlrSyntaxErrorInfo> _errors = new List<AntlrSyntaxErrorInfo>();
 
-    public SyntaxErrorNotificationListener(WorkspaceFileUri uri, CodeKind codeKind) 
-    :base(uri, codeKind) { }
+    public SyntaxErrorNotificationListener(WorkspaceFileUri uri, ISyntaxErrorMessageService messageService) 
+    :base(uri, messageService) { }
 
-    public IEnumerable<AntlrSyntaxErrorInfo> Errors => _errors;
+    protected override List<AntlrSyntaxErrorInfo> Errors { get; } = [];
 
     public override void SyntaxError(IRecognizer recognizer, IToken offendingSymbol, int line, int charPositionInLine, string msg, RecognitionException e)
     {
-        _errors.Add(new AntlrSyntaxErrorInfo
-        {
-            Uri = Uri,
-            CodeKind = CodeKind,
-
-            Message = msg,
-            Exception = e,
-            OffendingSymbol = offendingSymbol,
-
-            LineNumber = line,
-            Position = charPositionInLine,
-        });
+        var info = GetErrorInfo(offendingSymbol, line, charPositionInLine, msg, e);
+        _errors.Add(info);
     }
 }

--- a/Server/Rubberduck.Parsing/Exceptions/ThrowingSyntaxErrorListener.cs
+++ b/Server/Rubberduck.Parsing/Exceptions/ThrowingSyntaxErrorListener.cs
@@ -1,27 +1,18 @@
 ﻿using Antlr4.Runtime;
 using Rubberduck.InternalApi.Extensions;
-using Rubberduck.Parsing.Model;
 
 namespace Rubberduck.Parsing.Exceptions;
 
 public class ThrowingSyntaxErrorListener : RubberduckParseErrorListenerBase
 {
-    public ThrowingSyntaxErrorListener(WorkspaceFileUri uri, CodeKind codeKind) :base(uri, codeKind) { }
+    public ThrowingSyntaxErrorListener(WorkspaceFileUri uri, ISyntaxErrorMessageService? messageService) 
+        :base(uri, messageService) { }
+
+    protected override List<AntlrSyntaxErrorInfo> Errors { get; } = [];
 
     public override void SyntaxError(IRecognizer recognizer, IToken offendingSymbol, int line, int charPositionInLine, string msg, RecognitionException e)
     {
-        throw new SyntaxErrorException(
-            new AntlrSyntaxErrorInfo
-            {
-                Uri = Uri,
-                CodeKind = CodeKind,
-
-                Message = msg,
-                Exception = e,
-                OffendingSymbol = offendingSymbol,
-
-                LineNumber = line,
-                Position = charPositionInLine,
-            });
+        var info = GetErrorInfo(offendingSymbol, line, charPositionInLine, msg, e);
+        throw new SyntaxErrorException(info);
     }
 }

--- a/Server/Rubberduck.Parsing/Model/ComReflection/ComBase.cs
+++ b/Server/Rubberduck.Parsing/Model/ComReflection/ComBase.cs
@@ -1,7 +1,9 @@
 ﻿using System.Diagnostics;
 using System.Runtime.InteropServices.ComTypes;
 using System.Runtime.Serialization;
+using Rubberduck.InternalApi.Extensions;
 using Rubberduck.InternalApi.Model;
+using Rubberduck.InternalApi.Model.Declarations.Symbols;
 using FUNCDESC = System.Runtime.InteropServices.ComTypes.FUNCDESC;
 
 namespace Rubberduck.Parsing.Model.ComReflection;
@@ -37,7 +39,7 @@ public abstract class ComBase : IComBase
     [DataMember(IsRequired = true)]
     public IComBase Parent { get; protected set; }
 
-    public ComProject Project => Parent != null ? Parent.Project : this as ComProject;
+    public ComProject Project => Parent != null ? Parent.Project : (ComProject)this;
 
     protected ComBase(IComBase parent, ITypeLib typeLib, int index)
     {

--- a/Server/Rubberduck.Parsing/Model/ComReflection/ComBase.cs
+++ b/Server/Rubberduck.Parsing/Model/ComReflection/ComBase.cs
@@ -39,7 +39,7 @@ public abstract class ComBase : IComBase
     [DataMember(IsRequired = true)]
     public IComBase Parent { get; protected set; }
 
-    public ComProject Project => Parent != null ? Parent.Project : (ComProject)this;
+    public ComProject Project => Parent != null ? Parent.Project : this as ComProject;
 
     protected ComBase(IComBase parent, ITypeLib typeLib, int index)
     {

--- a/Server/Rubberduck.Parsing/Model/ComReflection/ComCoClass.cs
+++ b/Server/Rubberduck.Parsing/Model/ComReflection/ComCoClass.cs
@@ -7,6 +7,8 @@ using TYPEATTR = System.Runtime.InteropServices.ComTypes.TYPEATTR;
 using IMPLTYPEFLAGS = System.Runtime.InteropServices.ComTypes.IMPLTYPEFLAGS;
 using TYPEFLAGS = System.Runtime.InteropServices.ComTypes.TYPEFLAGS;
 using Rubberduck.InternalApi.Model;
+using Rubberduck.InternalApi.Model.Declarations.Symbols;
+using Rubberduck.InternalApi.Extensions;
 
 namespace Rubberduck.Parsing.Model.ComReflection;
 
@@ -101,5 +103,12 @@ public class ComCoClass : ComType, IComTypeWithMembers
         {
             DefaultInterface = VisibleInterfaces.FirstOrDefault();
         }
+    }
+
+    public override Symbol ToSymbol(WorkspaceFileUri uri)
+    {
+        var instancing = Instancing.PublicNotCreatable; // TODO
+        var children = new List<Symbol>(); // TODO
+        return new ClassModuleSymbol(instancing, Name, uri, children, isUserDefined: false); 
     }
 }

--- a/Server/Rubberduck.Parsing/Model/ComReflection/ComEnumeration.cs
+++ b/Server/Rubberduck.Parsing/Model/ComReflection/ComEnumeration.cs
@@ -1,7 +1,9 @@
 ﻿using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.ComTypes;
 using System.Runtime.Serialization;
+using Rubberduck.InternalApi.Extensions;
 using Rubberduck.InternalApi.Model;
+using Rubberduck.InternalApi.Model.Declarations.Symbols;
 using Rubberduck.VBEditor.Utility;
 using TYPEATTR = System.Runtime.InteropServices.ComTypes.TYPEATTR;
 using VARDESC = System.Runtime.InteropServices.ComTypes.VARDESC;
@@ -35,5 +37,11 @@ public class ComEnumeration : ComType
                 Members.Add(new ComEnumerationMember(this, info, desc));
             }
         }
+    }
+
+    public override Symbol ToSymbol(WorkspaceFileUri uri)
+    {
+        var children = Members.Select(e => new EnumMemberSymbol(e.Name, uri.GetChildSymbolUri(Name), e.Value.ToString()));
+        return new EnumSymbol(Name, uri, InternalApi.Model.Accessibility.Public, children, isUserDefined: false);
     }
 }

--- a/Server/Rubberduck.Parsing/Model/ComReflection/ComField.cs
+++ b/Server/Rubberduck.Parsing/Model/ComReflection/ComField.cs
@@ -2,7 +2,9 @@
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.ComTypes;
 using System.Runtime.Serialization;
+using Rubberduck.InternalApi.Extensions;
 using Rubberduck.InternalApi.Model;
+using Rubberduck.InternalApi.Model.Declarations.Symbols;
 using Rubberduck.VBEditor.Utility;
 using TYPEATTR = System.Runtime.InteropServices.ComTypes.TYPEATTR;
 using TYPEDESC = System.Runtime.InteropServices.ComTypes.TYPEDESC;
@@ -133,5 +135,21 @@ public class ComField
                 _valueType = result;
             }
         }
+    }
+
+    public Symbol ToSymbol(WorkspaceFileUri workspaceFileUri)
+    {
+        if (Type == DeclarationType.Constant)
+        {
+            return new ConstantDeclarationSymbol(Name, workspaceFileUri, InternalApi.Model.Accessibility.Public, ValueType, DefaultValue.ToString())
+            {
+                IsUserDefined = false,
+            };
+        }
+
+        return new VariableDeclarationSymbol(Name, workspaceFileUri, InternalApi.Model.Accessibility.Public, ValueType)
+        {
+            IsUserDefined = false,
+        };
     }
 }

--- a/Server/Rubberduck.Parsing/Model/ComReflection/ComInterface.cs
+++ b/Server/Rubberduck.Parsing/Model/ComReflection/ComInterface.cs
@@ -10,6 +10,8 @@ using TYPEFLAGS = System.Runtime.InteropServices.ComTypes.TYPEFLAGS;
 using TYPELIBATTR = System.Runtime.InteropServices.ComTypes.TYPELIBATTR;
 using VARDESC = System.Runtime.InteropServices.ComTypes.VARDESC;
 using Rubberduck.InternalApi.Model;
+using Rubberduck.InternalApi.Model.Declarations.Symbols;
+using Rubberduck.InternalApi.Extensions;
 
 namespace Rubberduck.Parsing.Model.ComReflection;
 
@@ -127,5 +129,15 @@ public class ComInterface : ComType, IComTypeWithMembers
                 _properties.Add(new ComField(this, info, names[0], property, index, DeclarationType.Property));
             }
         }
+    }
+
+    public override Symbol ToSymbol(WorkspaceFileUri uri)
+    {
+        var children = Members.Select(e => e.ToSymbol(uri.GetChildSymbolUri(Name)));
+        return new ClassModuleSymbol(Instancing.PublicNotCreatable, Name, uri, children)
+        {
+            IsUserDefined = false,
+            Detail = Documentation.DocString,
+        };
     }
 }

--- a/Server/Rubberduck.Parsing/Model/ComReflection/ComLibraryProvider.cs
+++ b/Server/Rubberduck.Parsing/Model/ComReflection/ComLibraryProvider.cs
@@ -38,7 +38,7 @@ public class ComLibraryProvider : IComLibraryProvider
 
     public ITypeLib LoadTypeLibrary(string libraryPath)
     {
-        LoadTypeLibEx(libraryPath, REGKIND.REGKIND_NONE, out var typeLibrary);
+        var hresult = LoadTypeLibEx(libraryPath, REGKIND.REGKIND_NONE, out var typeLibrary);
         return typeLibrary;
     }
 

--- a/Server/Rubberduck.Parsing/Model/ComReflection/ComMember.cs
+++ b/Server/Rubberduck.Parsing/Model/ComReflection/ComMember.cs
@@ -7,6 +7,8 @@ using FUNCDESC = System.Runtime.InteropServices.ComTypes.FUNCDESC;
 using INVOKEKIND = System.Runtime.InteropServices.ComTypes.INVOKEKIND;
 using FUNCFLAGS = System.Runtime.InteropServices.ComTypes.FUNCFLAGS;
 using Rubberduck.InternalApi.Model;
+using Rubberduck.InternalApi.Extensions;
+using Rubberduck.InternalApi.Model.Declarations.Symbols;
 
 namespace Rubberduck.Parsing.Model.ComReflection;
 
@@ -137,6 +139,60 @@ public class ComMember : ComBase
         {
             Parameters.Last().IsParamArray = true;
         }
+    }
+
+    internal Symbol ToSymbol(WorkspaceFileUri parentUri)
+    {
+        var children = Parameters.Select(e => e.ToSymbol(parentUri.GetChildSymbolUri(Name)));
+        Symbol symbol;
+        switch (Type)
+        {
+            case DeclarationType.Function:
+                symbol = new FunctionSymbol(Name, parentUri, InternalApi.Model.Accessibility.Public, children.OfType<ParameterSymbol>(), AsTypeName?.TypeName)
+                {
+                    IsUserDefined = false,
+                    Detail = Documentation?.DocString ?? string.Empty,
+                };
+                break;
+            case DeclarationType.Procedure:
+                symbol = new ProcedureSymbol(Name, parentUri, InternalApi.Model.Accessibility.Public, children.OfType<ParameterSymbol>())
+                {
+                    IsUserDefined = false,
+                    Detail = Documentation?.DocString ?? string.Empty,
+                };
+                break;
+            case DeclarationType.PropertyGet:
+                symbol = new PropertyGetSymbol(Name, parentUri, InternalApi.Model.Accessibility.Public, children.OfType<ParameterSymbol>(), AsTypeName?.TypeName)
+                {
+                    IsUserDefined = false,
+                    Detail = Documentation?.DocString ?? string.Empty,
+                };
+                break;
+            case DeclarationType.PropertyLet:
+                symbol = new PropertyLetSymbol(Name, parentUri, InternalApi.Model.Accessibility.Public, children.OfType<ParameterSymbol>())
+                {
+                    IsUserDefined = false,
+                    Detail = Documentation?.DocString ?? string.Empty,
+                };
+                break;
+            case DeclarationType.PropertySet:
+                symbol = new PropertySetSymbol(Name, parentUri, InternalApi.Model.Accessibility.Public, children.OfType<ParameterSymbol>())
+                {
+                    IsUserDefined = false,
+                    Detail = Documentation?.DocString ?? string.Empty,
+                };
+                break;
+            case DeclarationType.Event:
+                symbol = new EventMemberSymbol(Name, parentUri, InternalApi.Model.Accessibility.Public, children.OfType<ParameterSymbol>())
+                {
+                    IsUserDefined = false,
+                    Detail = Documentation?.DocString ?? string.Empty,
+                };
+                break;
+            default:
+                throw new NotSupportedException();
+        }
+        return symbol;
     }
 
     private string MemberDeclaration

--- a/Server/Rubberduck.Parsing/Model/ComReflection/ComMember.cs
+++ b/Server/Rubberduck.Parsing/Model/ComReflection/ComMember.cs
@@ -183,7 +183,7 @@ public class ComMember : ComBase
                 };
                 break;
             case DeclarationType.Event:
-                symbol = new EventMemberSymbol(Name, parentUri, InternalApi.Model.Accessibility.Public, children.OfType<ParameterSymbol>())
+                symbol = new EventSymbol(Name, parentUri, InternalApi.Model.Accessibility.Public, children.OfType<ParameterSymbol>())
                 {
                     IsUserDefined = false,
                     Detail = Documentation?.DocString ?? string.Empty,

--- a/Server/Rubberduck.Parsing/Model/ComReflection/ComModule.cs
+++ b/Server/Rubberduck.Parsing/Model/ComReflection/ComModule.cs
@@ -10,6 +10,8 @@ using CALLCONV = System.Runtime.InteropServices.ComTypes.CALLCONV;
 using Rubberduck.Unmanaged.TypeLibs.Abstract;
 using Rubberduck.Unmanaged.TypeLibs.Utility;
 using Rubberduck.InternalApi.Model;
+using Rubberduck.InternalApi.Model.Declarations.Symbols;
+using Rubberduck.InternalApi.Extensions;
 
 namespace Rubberduck.Parsing.Model.ComReflection;
 
@@ -87,5 +89,17 @@ public class ComModule : ComType, IComTypeWithMembers, IComTypeWithFields
                 _members.Add(new ComMember(this, info, member));
             }
         }
+    }
+
+    public override Symbol ToSymbol(WorkspaceFileUri uri)
+    {
+        var children = Members.Select(com => com.ToSymbol(uri.GetChildSymbolUri(com.Name)))
+            .Concat(Fields.Select(com => com.ToSymbol(uri.GetChildSymbolUri(com.Name)))
+        );
+
+        return new StandardModuleSymbol(Name, uri, [])
+        {
+            Detail = Documentation.DocString,
+        }.WithChildren(children);
     }
 }

--- a/Server/Rubberduck.Parsing/Model/ComReflection/ComParameter.cs
+++ b/Server/Rubberduck.Parsing/Model/ComReflection/ComParameter.cs
@@ -2,7 +2,9 @@
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.ComTypes;
 using System.Runtime.Serialization;
+using Rubberduck.InternalApi.Extensions;
 using Rubberduck.InternalApi.Model;
+using Rubberduck.InternalApi.Model.Declarations.Symbols;
 using Rubberduck.VBEditor.Utility;
 using ELEMDESC = System.Runtime.InteropServices.ComTypes.ELEMDESC;
 using PARAMFLAG = System.Runtime.InteropServices.ComTypes.PARAMFLAG;
@@ -153,5 +155,28 @@ public class ComParameter
         {
             _typeName = new ComTypeName(Project, ComVariant.TypeNames.TryGetValue(vt, out string? result) ? result : Tokens.Object);
         }
+    }
+
+    internal Symbol ToSymbol(WorkspaceUri parentUri)
+    {
+        ParameterSymbol symbol;
+        var modifier = IsByRef 
+            ? ParameterModifier.ExplicitByRef 
+            : ParameterModifier.ExplicitByVal;
+
+        if (IsParamArray)
+        {
+            symbol = new ParamArrayParameterSymbol(Name, parentUri, TypeName);
+        }
+        else if (IsOptional)
+        {
+            symbol = new OptionalParameterSymbol(Name, parentUri, modifier, TypeName, null);
+        }
+        else
+        {
+            symbol = new ParameterSymbol(Name, parentUri, modifier, TypeName);
+        }
+
+        return symbol;
     }
 }

--- a/Server/Rubberduck.Parsing/Model/ComReflection/ComProject.cs
+++ b/Server/Rubberduck.Parsing/Model/ComReflection/ComProject.cs
@@ -60,8 +60,9 @@ public class ComProject : ComBase
     private readonly List<ComStruct> _structs = [];
     public IEnumerable<ComStruct> Structs => _structs;
 
-    //Note - Enums and Types should enumerate *last*. That will prevent a duplicate module in the unlikely(?)
-    //instance where the TypeLib defines a module named "Enums" or "Types".
+    //Note - Enums and Types should enumerate *last*.
+    //That will prevent a duplicate module in the unlikely(?) instance
+    //where the TypeLib defines a module named "Enums" or "Types".
     public IEnumerable<IComType> Members => _modules.Cast<IComType>()
         .Union(_interfaces)
         .Union(_classes)

--- a/Server/Rubberduck.Parsing/Model/ComReflection/ComProject.cs
+++ b/Server/Rubberduck.Parsing/Model/ComReflection/ComProject.cs
@@ -9,7 +9,6 @@ using TYPELIBATTR = System.Runtime.InteropServices.ComTypes.TYPELIBATTR;
 using TYPEKIND = System.Runtime.InteropServices.ComTypes.TYPEKIND;
 using Rubberduck.InternalApi.Model.Declarations.Symbols;
 using Rubberduck.InternalApi.Extensions;
-using Rubberduck.InternalApi.ServerPlatform.LanguageServer;
 
 namespace Rubberduck.Parsing.Model.ComReflection;
 
@@ -31,7 +30,7 @@ public class ComProject : ComBase
     [DataMember(IsRequired = true)]
     public long MinorVersion { get; set; }
 
-    // YGNI...
+    // [Y]ou **[A]RE** [G]oing to [N]eed [I]t...
     // ReSharper disable once NotAccessedField.Local
 #pragma warning disable IDE0052 // Remove unread private members
     private readonly TypeLibTypeFlags _flags;
@@ -106,18 +105,18 @@ public class ComProject : ComBase
                     switch (typeAttributes.typekind)
                     {
                         case TYPEKIND.TKIND_ENUM:
-                            var enumeration = type ?? new ComEnumeration(this, typeLibrary, info, typeAttributes, index);
+                            var enumeration = type as ComEnumeration ?? new ComEnumeration(this, typeLibrary, info, typeAttributes, index);
                             Debug.Assert(enumeration is ComEnumeration);
-                            _enumerations.Add(enumeration as ComEnumeration);
+                            _enumerations.Add(enumeration);
                             if (type == null && !enumeration.Guid.Equals(Guid.Empty))
                             {
                                 KnownTypes.TryAdd(typeAttributes.guid, enumeration);
                             }
                             break;
                         case TYPEKIND.TKIND_COCLASS:
-                            var coclass = type ?? new ComCoClass(this, typeLibrary, info, typeAttributes, index);
+                            var coclass = type as ComCoClass ?? new ComCoClass(this, typeLibrary, info, typeAttributes, index);
                             Debug.Assert(coclass is ComCoClass && !coclass.Guid.Equals(Guid.Empty));
-                            _classes.Add(coclass as ComCoClass);
+                            _classes.Add(coclass);
                             if (type == null)
                             {
                                 KnownTypes.TryAdd(typeAttributes.guid, coclass);
@@ -125,9 +124,9 @@ public class ComProject : ComBase
                             break;
                         case TYPEKIND.TKIND_DISPATCH:
                         case TYPEKIND.TKIND_INTERFACE:
-                            var intface = type ?? new ComInterface(this, typeLibrary, info, typeAttributes, index);
+                            var intface = type as ComInterface ?? new ComInterface(this, typeLibrary, info, typeAttributes, index);
                             Debug.Assert(intface is ComInterface && !intface.Guid.Equals(Guid.Empty));
-                            _interfaces.Add(intface as ComInterface);
+                            _interfaces.Add(intface);
                             if (type == null)
                             {
                                 KnownTypes.TryAdd(typeAttributes.guid, intface);
@@ -138,9 +137,9 @@ public class ComProject : ComBase
                             _structs.Add(structure);
                             break;
                         case TYPEKIND.TKIND_MODULE:
-                            var module = type ?? new ComModule(this, typeLibrary, info, typeAttributes, index);
+                            var module = type as ComModule ?? new ComModule(this, typeLibrary, info, typeAttributes, index);
                             Debug.Assert(module is ComModule);
-                            _modules.Add(module as ComModule);
+                            _modules.Add(module);
                             if (type == null && !module.Guid.Equals(Guid.Empty))
                             {
                                 KnownTypes.TryAdd(typeAttributes.guid, module);
@@ -181,10 +180,8 @@ public class ComProject : ComBase
     public Symbol ToSymbol()
     {
         var uri = new WorkspaceFileUri(Path, new Uri(Directory.GetParent(Path)!.FullName));
-
-        var children = Modules.Select(e => e.ToSymbol(uri))
-            .Concat(CoClasses.Select(e => e.ToSymbol(uri)));
-
+        
+        var children = Members.Select(e => e.ToSymbol(uri));
         return new ProjectSymbol(Name, uri, children)
         {
             Detail = Documentation?.DocString,

--- a/Server/Rubberduck.Parsing/Model/ComReflection/ComStruct.cs
+++ b/Server/Rubberduck.Parsing/Model/ComReflection/ComStruct.cs
@@ -2,7 +2,9 @@
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.ComTypes;
 using System.Runtime.Serialization;
+using Rubberduck.InternalApi.Extensions;
 using Rubberduck.InternalApi.Model;
+using Rubberduck.InternalApi.Model.Declarations.Symbols;
 using Rubberduck.VBEditor.Utility;
 using TYPEATTR = System.Runtime.InteropServices.ComTypes.TYPEATTR;
 using VARDESC = System.Runtime.InteropServices.ComTypes.VARDESC;
@@ -39,5 +41,15 @@ public class ComStruct : ComType, IComTypeWithFields
                 _fields.Add(new ComField(this, info, names[0], desc, index, DeclarationType.UserDefinedTypeMember));
             }
         }
+    }
+
+    public override Symbol ToSymbol(WorkspaceFileUri uri)
+    {
+        var children = Fields.Select(e => new UserDefinedTypeMemberSymbol(e.Name, uri.GetChildSymbolUri(Name), e.ValueType) { IsUserDefined = false });
+        return new UserDefinedTypeSymbol(Name, uri, InternalApi.Model.Accessibility.Public, children) 
+        {
+            IsUserDefined = false,
+            Detail = Documentation.DocString,
+        };
     }
 }

--- a/Server/Rubberduck.Parsing/Model/ComReflection/ComType.cs
+++ b/Server/Rubberduck.Parsing/Model/ComReflection/ComType.cs
@@ -1,4 +1,6 @@
-﻿using System.Diagnostics;
+﻿using Rubberduck.InternalApi.Extensions;
+using Rubberduck.InternalApi.Model.Declarations.Symbols;
+using System.Diagnostics;
 using System.Runtime.InteropServices.ComTypes;
 using System.Runtime.Serialization;
 
@@ -10,6 +12,8 @@ public interface IComType : IComBase
     bool IsPreDeclared { get; }
     bool IsHidden { get; }
     bool IsRestricted { get; }
+
+    Symbol ToSymbol(WorkspaceFileUri uri);
 }
 
 public interface IComTypeWithMembers : IComType
@@ -62,4 +66,6 @@ public abstract class ComType : ComBase, IComType
         IsHidden = attrib.wTypeFlags.HasFlag(TYPEFLAGS.TYPEFLAG_FHIDDEN);
         IsRestricted = attrib.wTypeFlags.HasFlag(TYPEFLAGS.TYPEFLAG_FRESTRICTED);
     }
+
+    public abstract Symbol ToSymbol(WorkspaceFileUri uri);
 }

--- a/Server/Rubberduck.Parsing/Parsers/TokenStreamParserAdapterWithPreprocessing.cs
+++ b/Server/Rubberduck.Parsing/Parsers/TokenStreamParserAdapterWithPreprocessing.cs
@@ -34,13 +34,14 @@ public class TokenStreamParserAdapterWithPreprocessing<TContent> : IParser<TCont
         var tokenStream = _preprocessor.PreprocessTokenStream(uri, rawTokenStream, token);
         token.ThrowIfCancellationRequested();
 
-        var tree = _tokenStreamParser.Parse(uri, tokenStream ?? rawTokenStream, token, parserMode, parseListeners);
+        var tree = _tokenStreamParser.Parse(uri, tokenStream ?? rawTokenStream, token, out var errors, parserMode, parseListeners);
         return new ParseResult
         {
             Tree = tree,
             TokenStream = tokenStream ?? rawTokenStream,
             LogicalLines = null,
-            Listeners = parseListeners ?? []
+            Listeners = parseListeners ?? [],
+            SyntaxErrors = errors
         };
     }
 }

--- a/Server/Rubberduck.Parsing/Parsers/TokenStreamParserAdapterWithPreprocessing.cs
+++ b/Server/Rubberduck.Parsing/Parsers/TokenStreamParserAdapterWithPreprocessing.cs
@@ -23,7 +23,6 @@ public class TokenStreamParserAdapterWithPreprocessing<TContent> : IParser<TCont
         WorkspaceFileUri uri,
         TContent content,
         CancellationToken token,
-        CodeKind codeKind = CodeKind.SnippetCode,
         ParserMode parserMode = ParserMode.FallBackSllToLl,
         IEnumerable<IParseTreeListener>? parseListeners = null)
     {
@@ -32,10 +31,10 @@ public class TokenStreamParserAdapterWithPreprocessing<TContent> : IParser<TCont
         var rawTokenStream = _tokenStreamProvider.Tokens(content);
         token.ThrowIfCancellationRequested();
 
-        var tokenStream = _preprocessor.PreprocessTokenStream(uri, rawTokenStream, token, codeKind);
+        var tokenStream = _preprocessor.PreprocessTokenStream(uri, rawTokenStream, token);
         token.ThrowIfCancellationRequested();
 
-        var tree = _tokenStreamParser.Parse(uri, tokenStream ?? rawTokenStream, token, codeKind, parserMode, parseListeners);
+        var tree = _tokenStreamParser.Parse(uri, tokenStream ?? rawTokenStream, token, parserMode, parseListeners);
         return new ParseResult
         {
             Tree = tree,

--- a/Server/Rubberduck.Parsing/Parsers/TokenStreamParserStringParserAdapter.cs
+++ b/Server/Rubberduck.Parsing/Parsers/TokenStreamParserStringParserAdapter.cs
@@ -24,7 +24,7 @@ public class TokenStreamParserStringParserAdapter : IStringParser
 
         token.ThrowIfCancellationRequested();
 
-        var tree = _tokenStreamParser.Parse(uri, tokenStream, token, parserMode, parseListeners);
-        return new ParseResult { Tree = tree, TokenStream = tokenStream };
+        var tree = _tokenStreamParser.Parse(uri, tokenStream, token, out var errors, parserMode, parseListeners);
+        return new ParseResult { Tree = tree, TokenStream = tokenStream, SyntaxErrors = errors };
     }
 }

--- a/Server/Rubberduck.Parsing/Parsers/TokenStreamParserStringParserAdapter.cs
+++ b/Server/Rubberduck.Parsing/Parsers/TokenStreamParserStringParserAdapter.cs
@@ -17,14 +17,14 @@ public class TokenStreamParserStringParserAdapter : IStringParser
         _tokenStreamParser = tokenStreamParser;
     }
 
-    public ParseResult Parse(WorkspaceFileUri uri, string content, CancellationToken token, CodeKind codeKind, ParserMode parserMode, IEnumerable<IParseTreeListener>? parseListeners = null)
+    public ParseResult Parse(WorkspaceFileUri uri, string content, CancellationToken token, ParserMode parserMode, IEnumerable<IParseTreeListener>? parseListeners = null)
     {
         token.ThrowIfCancellationRequested();
         var tokenStream = _tokenStreamProvider.Tokens(content);
 
         token.ThrowIfCancellationRequested();
 
-        var tree = _tokenStreamParser.Parse(uri, tokenStream, token, codeKind, parserMode, parseListeners);
+        var tree = _tokenStreamParser.Parse(uri, tokenStream, token, parserMode, parseListeners);
         return new ParseResult { Tree = tree, TokenStream = tokenStream };
     }
 }

--- a/Server/Rubberduck.Parsing/Parsers/VBADateLiteralParser.cs
+++ b/Server/Rubberduck.Parsing/Parsers/VBADateLiteralParser.cs
@@ -21,7 +21,7 @@ public sealed class VBADateLiteralParser
         var tokens = new CommonTokenStream(lexer);
         var parser = new VBADateParser(tokens);
 
-        parser.AddErrorListener(new ThrowingSyntaxErrorListener(null!, CodeKind.SnippetCode)); // report or throw?
+        parser.AddErrorListener(new ThrowingSyntaxErrorListener(null!, null)); // report or throw?
         VBADateParser.CompilationUnitContext tree;
         try
         {

--- a/Server/Rubberduck.Parsing/Parsers/VBAPreprocessorParser.cs
+++ b/Server/Rubberduck.Parsing/Parsers/VBAPreprocessorParser.cs
@@ -1,12 +1,21 @@
 ﻿using Antlr4.Runtime;
 using Antlr4.Runtime.Tree;
+using Microsoft.Extensions.Logging;
+using Rubberduck.InternalApi.Services;
+using Rubberduck.InternalApi.Settings;
 using Rubberduck.Parsing.Abstract;
+using Rubberduck.Parsing.Exceptions;
 using Rubberduck.Parsing.Grammar;
 
 namespace Rubberduck.Parsing.Parsers;
 
 public class VBAPreprocessorParser : TokenStreamParserBase<VBAConditionalCompilationParser>
 {
+    public VBAPreprocessorParser(ISyntaxErrorMessageService errorMessageService, ILogger<ITokenStreamParser> logger, RubberduckSettingsProvider settingsProvider, PerformanceRecordAggregator performance) 
+        : base(errorMessageService, logger, settingsProvider, performance)
+    {
+    }
+
     protected override VBAConditionalCompilationParser GetParser(ITokenStream tokenStream) => new(tokenStream);
 
     protected override IParseTree Parse(VBAConditionalCompilationParser parser) => parser.compilationUnit();

--- a/Server/Rubberduck.Parsing/Parsers/VBATokenStreamParser.cs
+++ b/Server/Rubberduck.Parsing/Parsers/VBATokenStreamParser.cs
@@ -1,12 +1,21 @@
 ﻿using Antlr4.Runtime;
 using Antlr4.Runtime.Tree;
+using Microsoft.Extensions.Logging;
+using Rubberduck.InternalApi.Services;
+using Rubberduck.InternalApi.Settings;
 using Rubberduck.Parsing.Abstract;
+using Rubberduck.Parsing.Exceptions;
 using Rubberduck.Parsing.Grammar;
 
 namespace Rubberduck.Parsing.Parsers;
 
 public class VBATokenStreamParser : TokenStreamParserBase<VBAParser>
 {
+    public VBATokenStreamParser(ISyntaxErrorMessageService errorMessageService, ILogger<ITokenStreamParser> logger, RubberduckSettingsProvider settingsProvider, PerformanceRecordAggregator performance) 
+        : base(errorMessageService, logger, settingsProvider, performance)
+    {
+    }
+
     protected override VBAParser GetParser(ITokenStream tokenStream) => new(tokenStream);
 
     protected override IParseTree Parse(VBAParser parser) => parser.startRule();
@@ -14,6 +23,11 @@ public class VBATokenStreamParser : TokenStreamParserBase<VBAParser>
 
 public class VBAMemberTokenStreamParser : TokenStreamParserBase<VBAMemberParser>
 {
+    public VBAMemberTokenStreamParser(ISyntaxErrorMessageService errorMessageService, ILogger<ITokenStreamParser> logger, RubberduckSettingsProvider settingsProvider, PerformanceRecordAggregator performance)
+        : base(errorMessageService, logger, settingsProvider, performance)
+    {
+    }
+
     protected override VBAMemberParser GetParser(ITokenStream tokenStream) => new(tokenStream);
 
     protected override IParseTree Parse(VBAMemberParser parser) => parser.startRule();

--- a/Server/Rubberduck.Parsing/PreProcessing/CompilationArgumentsCache.cs
+++ b/Server/Rubberduck.Parsing/PreProcessing/CompilationArgumentsCache.cs
@@ -1,4 +1,5 @@
-﻿using Rubberduck.Parsing.Abstract;
+﻿using Rubberduck.InternalApi.Extensions;
+using Rubberduck.Parsing.Abstract;
 
 namespace Rubberduck.Parsing.PreProcessing;
 
@@ -6,7 +7,7 @@ public class CompilationArgumentsCache : ICompilationArgumentsCache
 {
     private readonly ICompilationArgumentsProvider _provider;
     private readonly Dictionary<Uri, Dictionary<string, short>> _compilationArguments = [];
-    private readonly HashSet<Uri> _projectsWhoseCompilationArgumentsChanged = [];
+    private readonly HashSet<WorkspaceUri> _projectsWhoseCompilationArgumentsChanged = [];
 
     public CompilationArgumentsCache(ICompilationArgumentsProvider compilationArgumentsProvider)
     {
@@ -15,12 +16,12 @@ public class CompilationArgumentsCache : ICompilationArgumentsCache
 
     public VBAPredefinedCompilationConstants PredefinedCompilationConstants => _provider.PredefinedCompilationConstants;
 
-    public Dictionary<string, short> UserDefinedCompilationArguments(Uri workspaceUri)
+    public Dictionary<string, short> UserDefinedCompilationArguments(WorkspaceUri workspaceUri)
     {
-        return _compilationArguments.TryGetValue(workspaceUri, out var args) ? args : [];
+        return _compilationArguments.TryGetValue(workspaceUri.WorkspaceRoot, out var args) ? args : [];
     }
 
-    public void ReloadCompilationArguments(IEnumerable<Uri> workspaceUris)
+    public void ReloadCompilationArguments(IEnumerable<WorkspaceUri> workspaceUris)
     {
         foreach (var uri in workspaceUris)
         {
@@ -35,12 +36,12 @@ public class CompilationArgumentsCache : ICompilationArgumentsCache
         }
     }
 
-    private void ReloadCompilationArguments(Uri workspaceUri)
+    private void ReloadCompilationArguments(WorkspaceUri workspaceUri)
     {
         _compilationArguments[workspaceUri] = _provider.UserDefinedCompilationArguments(workspaceUri);
     }
 
-    public IReadOnlyCollection<Uri> ProjectWhoseCompilationArgumentsChanged()
+    public IReadOnlyCollection<WorkspaceUri> ProjectWhoseCompilationArgumentsChanged()
     {
         return _projectsWhoseCompilationArgumentsChanged;
     }
@@ -50,7 +51,7 @@ public class CompilationArgumentsCache : ICompilationArgumentsCache
         _projectsWhoseCompilationArgumentsChanged.Clear();
     }
 
-    public void RemoveCompilationArgumentsFromCache(IEnumerable<Uri> workspaceUris)
+    public void RemoveCompilationArgumentsFromCache(IEnumerable<WorkspaceUri> workspaceUris)
     {
         foreach (var uri in workspaceUris)
         {

--- a/Server/Rubberduck.Parsing/PreProcessing/CompilationArgumentsProvider.cs
+++ b/Server/Rubberduck.Parsing/PreProcessing/CompilationArgumentsProvider.cs
@@ -1,4 +1,5 @@
-﻿using Rubberduck.InternalApi.Model.Declarations.Execution;
+﻿using Rubberduck.InternalApi.Extensions;
+using Rubberduck.InternalApi.Model.Declarations.Execution;
 using Rubberduck.InternalApi.Model.Declarations.Execution.Values;
 using Rubberduck.InternalApi.Model.Declarations.Symbols;
 using Rubberduck.InternalApi.Services;
@@ -24,7 +25,7 @@ public class CompilationArgumentsProvider : ICompilationArgumentsProvider
 
     public VBAPredefinedCompilationConstants PredefinedCompilationConstants { get; }
 
-    public Dictionary<string, short> UserDefinedCompilationArguments(Uri uri)
+    public Dictionary<string, short> UserDefinedCompilationArguments(WorkspaceUri uri)
     {
         return GetUserDefinedCompilationArguments(uri);
     }
@@ -53,7 +54,7 @@ public class WorkspaceCompilationArgumentsProvider : ICompilationArgumentsProvid
     public VBAPredefinedCompilationConstants PredefinedCompilationConstants => 
         new(_state.ActiveWorkspace?.ExecutionContext.LanguageVersion ?? throw new InvalidOperationException("Operation requires an active workspace"));
 
-    public Dictionary<string, short> UserDefinedCompilationArguments(Uri workspaceRoot)
+    public Dictionary<string, short> UserDefinedCompilationArguments(WorkspaceUri workspaceRoot)
     {
         var context = _state.GetWorkspace(workspaceRoot).ExecutionContext;
         return context.ResolvedSymbols.OfType<PrecompilerConstantSymbol>()

--- a/Server/Rubberduck.Parsing/PreProcessing/VBAPreprocessor.cs
+++ b/Server/Rubberduck.Parsing/PreProcessing/VBAPreprocessor.cs
@@ -18,11 +18,11 @@ public sealed class VBAPreprocessor : ITokenStreamPreprocessor
         _parser = preprocessorParser;
     }
 
-    public CommonTokenStream? PreprocessTokenStream(WorkspaceFileUri uri, CommonTokenStream tokenStream, CancellationToken token, CodeKind codeKind = CodeKind.SnippetCode)
+    public CommonTokenStream? PreprocessTokenStream(WorkspaceFileUri uri, CommonTokenStream tokenStream, CancellationToken token)
     {
         token.ThrowIfCancellationRequested();
 
-        var tree = _parser.Parse(uri, tokenStream, token, codeKind);
+        var tree = _parser.Parse(uri, tokenStream, token);
         token.ThrowIfCancellationRequested();
 
         var charStream = tokenStream.TokenSource.InputStream;

--- a/Server/Rubberduck.Parsing/PreProcessing/VBAPreprocessor.cs
+++ b/Server/Rubberduck.Parsing/PreProcessing/VBAPreprocessor.cs
@@ -30,7 +30,7 @@ public sealed class VBAPreprocessor : ITokenStreamPreprocessor
         Dictionary<string, short> userCompilationArguments = [];
         try
         {
-            userCompilationArguments = _compilationArgumentsProvider.UserDefinedCompilationArguments(uri.WorkspaceRoot);
+            userCompilationArguments = _compilationArgumentsProvider.UserDefinedCompilationArguments(uri);
         }
         catch (Exception)
         {

--- a/Server/Rubberduck.Parsing/PreProcessing/VBAPreprocessor.cs
+++ b/Server/Rubberduck.Parsing/PreProcessing/VBAPreprocessor.cs
@@ -22,7 +22,7 @@ public sealed class VBAPreprocessor : ITokenStreamPreprocessor
     {
         token.ThrowIfCancellationRequested();
 
-        var tree = _parser.Parse(uri, tokenStream, token);
+        var tree = _parser.Parse(uri, tokenStream, token, out _ /*out var errors*/);
         token.ThrowIfCancellationRequested();
 
         var charStream = tokenStream.TokenSource.InputStream;

--- a/Server/Rubberduck.Parsing/Rubberduck.Parsing.csproj
+++ b/Server/Rubberduck.Parsing/Rubberduck.Parsing.csproj
@@ -6,6 +6,7 @@
     <LangVersion>12.0</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Server/Rubberduck.Parsing/_v3/Pipeline/Abstract/DataflowPipeline.cs
+++ b/Server/Rubberduck.Parsing/_v3/Pipeline/Abstract/DataflowPipeline.cs
@@ -30,7 +30,11 @@ public abstract class DataflowPipeline : ServiceBase, IDisposable
     public void FaultPipeline(Exception exception)
     {
         Exception = exception;
-        TokenSource?.Cancel();
+        try
+        {
+            TokenSource?.Cancel();
+        }
+        catch (ObjectDisposedException) { }
     }
 
     protected void Link<T>(ISourceBlock<T> source, ITargetBlock<T> target, DataflowLinkOptions? options = null)

--- a/Server/Rubberduck.Parsing/_v3/Pipeline/Abstract/DataflowPipeline.cs
+++ b/Server/Rubberduck.Parsing/_v3/Pipeline/Abstract/DataflowPipeline.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Extensions.Logging;
 using Rubberduck.InternalApi.Services;
 using Rubberduck.InternalApi.Settings;
+using System.Collections.Concurrent;
 using System.Threading.Tasks.Dataflow;
 
 namespace Rubberduck.Parsing._v3.Pipeline.Abstract;
@@ -26,15 +27,24 @@ public abstract class DataflowPipeline : ServiceBase, IDisposable
     protected virtual CancellationTokenSource? TokenSource { get; set; }
     protected CancellationToken Token => TokenSource?.Token ?? CancellationToken.None;
 
-    public Exception? Exception { get; private set; }
+    private ConcurrentStack<Exception> _exceptions = [];
+    public Exception? Exception => _exceptions.TryPeek(out var exception) ? exception : null;
+
     public void FaultPipeline(Exception exception)
     {
-        Exception = exception;
-        try
+        if (Exception is null)
         {
-            TokenSource?.Cancel();
+            _exceptions.Push(exception);
+            try
+            {
+                TokenSource?.Cancel();
+            }
+            catch (ObjectDisposedException) { }
         }
-        catch (ObjectDisposedException) { }
+        else
+        {
+            LogWarning("Pipeline was already faulted", $"{exception.GetType().Name}: {exception.Message}");
+        }
     }
 
     protected void Link<T>(ISourceBlock<T> source, ITargetBlock<T> target, DataflowLinkOptions? options = null)
@@ -67,7 +77,10 @@ public abstract class DataflowPipeline : ServiceBase, IDisposable
         else
         {
             LogException(exception, $"Dataflow block '{name ?? typeof(IDataflowBlock).Name}' was faulted.");
-            FaultPipeline(exception);
+            if (Exception is null)
+            {
+                FaultPipeline(exception);
+            }
         }
     }
 

--- a/Server/Rubberduck.Parsing/_v3/Pipeline/Abstract/DataflowPipelineSection.cs
+++ b/Server/Rubberduck.Parsing/_v3/Pipeline/Abstract/DataflowPipelineSection.cs
@@ -24,12 +24,7 @@ public abstract class DataflowPipelineSection<TInput, TState> : DataflowPipeline
         _parent = parent;
     }
 
-    private TState _state = null!;
-    public TState State
-    {
-        get => _state;
-        protected set => _state = value;
-    }
+    public virtual TState State { get; protected set; }
 
     /// <summary>
     /// Gets the <c>IDataflowBlock</c> that receives the input when the pipeline is started.
@@ -168,7 +163,7 @@ public abstract class DataflowPipelineSection<TInput, TState> : DataflowPipeline
     }
 
     protected void LogTaskCompletionState(StringBuilder builder, Task completion, string name, TimeSpan? elapsed) => 
-        builder.AppendLine($"\t{LogTaskCompletionIcon(completion)}[{name}] status: {completion.Status}" + (elapsed.HasValue ? $" ⏱️ total: {Performance.TotalElapsed(name)} | avg.:{Performance.AverageElapsed(name)}" : string.Empty));
+        builder.AppendLine($"\t{LogTaskCompletionIcon(completion)}[{name}] status: {completion.Status}" + (elapsed.HasValue ? $" ⏱️{Performance.TotalElapsed(name)}" : string.Empty));
 
     protected TResult RunTransformBlock<T, TResult>(IDataflowBlock block, T param, Func<T, TResult> action, [CallerMemberName] string? actionName = null, bool logPerformance = true) where TResult : class
     {

--- a/Server/Rubberduck.Parsing/_v3/Pipeline/Abstract/DataflowPipelineSection.cs
+++ b/Server/Rubberduck.Parsing/_v3/Pipeline/Abstract/DataflowPipelineSection.cs
@@ -12,7 +12,7 @@ public abstract class DataflowPipelineSection<TInput, TState> : DataflowPipeline
 {
     private readonly DataflowPipeline _parent;
 
-    protected DataflowPipelineSection(DataflowPipeline parent,
+    protected DataflowPipelineSection(DataflowPipeline parent, 
         ILogger logger, RubberduckSettingsProvider settingsProvider, PerformanceRecordAggregator performance)
         : base(logger, settingsProvider, performance)
     {
@@ -53,18 +53,18 @@ public abstract class DataflowPipelineSection<TInput, TState> : DataflowPipeline
             throw new InvalidOperationException($"{nameof(DefineSectionBlocks)} unexpectedly did not return any dataflow blocks.");
         }
 
-        if (state != null)
-        {
-            SetInitialState(state);
-        }
-
-        InputBlock = blocks.ElementAt(0);
-
-        ((ITargetBlock<TInput>)InputBlock).Post(input);
-        InputBlock.Complete();
-
         try
         {
+            if (state != null)
+            {
+                SetInitialState(state);
+            }
+
+            InputBlock = blocks.ElementAt(0);
+
+            ((ITargetBlock<TInput>)InputBlock).Post(input);
+            InputBlock.Complete();
+
             await Completion;
         }
         catch (Exception exception)

--- a/Server/Rubberduck.Parsing/_v3/Pipeline/Abstract/DataflowPipelineSection.cs
+++ b/Server/Rubberduck.Parsing/_v3/Pipeline/Abstract/DataflowPipelineSection.cs
@@ -1,15 +1,20 @@
 ﻿using Microsoft.Extensions.Logging;
 using Rubberduck.InternalApi.Services;
 using Rubberduck.InternalApi.Settings;
+using System.Collections.Concurrent;
 using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading.Tasks.Dataflow;
+using System.Windows.Documents;
 
 namespace Rubberduck.Parsing._v3.Pipeline.Abstract;
 
 public abstract class DataflowPipelineSection<TInput, TState> : DataflowPipeline where TState : class
 {
+    private readonly Stopwatch _stopwatch = new();
     private readonly DataflowPipeline _parent;
 
     protected DataflowPipelineSection(DataflowPipeline parent, 
@@ -19,7 +24,12 @@ public abstract class DataflowPipelineSection<TInput, TState> : DataflowPipeline
         _parent = parent;
     }
 
-    public TState State { get; protected set; } = default!;
+    private TState _state = null!;
+    public TState State
+    {
+        get => _state;
+        protected set => _state = value;
+    }
 
     /// <summary>
     /// Gets the <c>IDataflowBlock</c> that receives the input when the pipeline is started.
@@ -62,6 +72,8 @@ public abstract class DataflowPipelineSection<TInput, TState> : DataflowPipeline
 
             InputBlock = blocks.ElementAt(0);
 
+            _stopwatch.Reset();
+            _stopwatch.Start();
             ((ITargetBlock<TInput>)InputBlock).Post(input);
             InputBlock.Complete();
 
@@ -73,6 +85,7 @@ public abstract class DataflowPipelineSection<TInput, TState> : DataflowPipeline
         }
         finally
         {
+            _stopwatch.Stop();
             LogPipelineCompletionState();
         }
     }
@@ -104,37 +117,90 @@ public abstract class DataflowPipelineSection<TInput, TState> : DataflowPipeline
         FaultPipeline(exception);
     }
 
-    protected abstract ImmutableArray<(string Name, IDataflowBlock Block)> DataflowBlocks { get; }
+    protected abstract Dictionary<string, IDataflowBlock> DataflowBlocks { get; }
 
-    public virtual void LogPipelineCompletionState()
+    public void LogPipelineCompletionState()
     {
         var builder = new StringBuilder();
         builder.AppendLine($"Pipeline ({GetType().Name}) completion status");
+        builder.AppendLine($"\t{(Completion.IsCompletedSuccessfully ? "✅" : LogTaskCompletionIcon(Completion, true))}[{GetType().Name}]: ⏱️{_stopwatch.Elapsed}");
+        LogAdditionalPipelineSectionCompletionInfo(builder, GetType().Name);
 
         foreach (var (name, block) in DataflowBlocks)
         {
-            builder.AppendLine($"\t{(block.Completion.IsCompletedSuccessfully ? "✔️": "◼️")}[{name}] status: {block.Completion.Status}");
+            var elapsed = Performance.TotalElapsed(name);
+            LogTaskCompletionState(builder, block.Completion, name, elapsed);
         }
         LogDebug(builder.ToString());
     }
 
-    protected virtual TResult RunTransformBlock<T, TResult>(IDataflowBlock block, T param, Func<T, TResult> action, [CallerMemberName] string? actionName = null, bool logPerformance = true) where TResult : class
+    protected virtual void LogAdditionalPipelineSectionCompletionInfo(StringBuilder builder, string name)
+    {
+    }
+
+    protected string LogTaskCompletionIcon(Task completion, bool isSection = false)
+    {
+        string icon;
+        if (completion.IsCompletedSuccessfully)
+        {
+            icon = "✔️";
+        }
+        else
+        {
+            if (!completion.IsCompleted)
+            {
+                icon = "⌛";
+            }
+            else if (completion.IsFaulted)
+            {
+                icon = "❌";
+            }
+            else if (completion.IsCanceled)
+            {
+                icon = isSection ? "⛔" : "💤";
+            }
+            else
+            {
+                icon = "◼️";
+            }
+        }
+        return icon;
+    }
+
+    protected void LogTaskCompletionState(StringBuilder builder, Task completion, string name, TimeSpan? elapsed) => 
+        builder.AppendLine($"\t{LogTaskCompletionIcon(completion)}[{name}] status: {completion.Status}" + (elapsed.HasValue ? $" ⏱️ total: {Performance.TotalElapsed(name)} | avg.:{Performance.AverageElapsed(name)}" : string.Empty));
+
+    protected TResult RunTransformBlock<T, TResult>(IDataflowBlock block, T param, Func<T, TResult> action, [CallerMemberName] string? actionName = null, bool logPerformance = true) where TResult : class
     {
         TResult? result = null;
         if (!TryRunAction(() =>
         {
             ThrowIfCancellationRequested();
             result = action.Invoke(param);
-
-        }, out var exception, actionName, logPerformance) && exception != null)
+        }, out var exception, out var elapsed, actionName, logPerformance) && exception != null)
         {
             FaultDataflowBlock(actionName, block, exception);
         }
 
-        return result ?? throw new InvalidOperationException("Result was unexpectedly null.");
+        return result ?? throw new InvalidOperationException("Result was unexpectedly null.", exception);
     }
 
-    protected virtual TResult RunTransformBlock<T, TResult>(IDataflowBlock block, T param, Func<T, CancellationToken, TResult> action, [CallerMemberName] string? actionName = null, bool logPerformance = true) where TResult : class
+    protected TResult RunTransformBlock<T, TResult>(IDataflowBlock block, T param, Func<T, TResult> action, out TimeSpan elapsed, [CallerMemberName] string? actionName = null, bool logPerformance = true) where TResult : class
+    {
+        TResult? result = null;
+        if (!TryRunAction(() =>
+        {
+            ThrowIfCancellationRequested();
+            result = action.Invoke(param);
+        }, out var exception, out elapsed, actionName, logPerformance) && exception != null)
+        {
+            FaultDataflowBlock(actionName, block, exception);
+        }
+
+        return result ?? throw new InvalidOperationException("Result was unexpectedly null.", exception);
+    }
+
+    protected TResult RunTransformBlock<T, TResult>(IDataflowBlock block, T param, Func<T, CancellationToken, TResult> action, [CallerMemberName] string? actionName = null, bool logPerformance = true) where TResult : class
     {
         TResult? result = null;
         if (!TryRunAction(() =>
@@ -142,35 +208,64 @@ public abstract class DataflowPipelineSection<TInput, TState> : DataflowPipeline
             ThrowIfCancellationRequested();
             result = action.Invoke(param, Token);
 
-        }, out var exception, actionName, logPerformance) && exception != null)
+        }, out var exception, out var elapsed, actionName, logPerformance) && exception != null)
         {
             FaultDataflowBlock(actionName, block, exception);
         }
 
-        return result ?? throw new InvalidOperationException("Result was unexpectedly null.");
+        return result ?? throw new InvalidOperationException("Result was unexpectedly null.", exception);
     }
 
-    protected virtual void RunActionBlock<T>(IDataflowBlock block, T param, Action<T> action, [CallerMemberName] string? actionName = null, bool logPerformance = true)
+    protected TResult RunTransformBlock<T, TResult>(IDataflowBlock block, T param, Func<T, CancellationToken, TResult> action, out TimeSpan elapsed, [CallerMemberName] string? actionName = null, bool logPerformance = true) where TResult : class
+    {
+        TResult? result = null;
+        if (!TryRunAction(() =>
+        {
+            ThrowIfCancellationRequested();
+            result = action.Invoke(param, Token);
+
+        }, out var exception, out elapsed, actionName, logPerformance) && exception != null)
+        {
+            FaultDataflowBlock(actionName, block, exception);
+        }
+
+        return result ?? throw new InvalidOperationException("Result was unexpectedly null.", exception);
+    }
+
+    protected void RunActionBlock<T>(IDataflowBlock block, T param, Action<T> action, [CallerMemberName] string? actionName = null, bool logPerformance = true)
     {
         if (!TryRunAction(() =>
         {
             ThrowIfCancellationRequested();
             action.Invoke(param);
 
-        }, out var exception, actionName, logPerformance) && exception != null)
+        }, out var exception, out var elapsed, actionName, logPerformance) && exception != null)
         {
             FaultDataflowBlock(actionName, block, exception);
         }
     }
 
-    protected virtual void RunActionBlock<T>(IDataflowBlock block, T param, Action<T, CancellationToken> action, [CallerMemberName] string? actionName = null, bool logPerformance = true)
+    protected void RunActionBlock<T>(IDataflowBlock block, T param, Action<T> action, out TimeSpan elapsed, [CallerMemberName] string? actionName = null, bool logPerformance = true)
+    {
+        if (!TryRunAction(() =>
+        {
+            ThrowIfCancellationRequested();
+            action.Invoke(param);
+
+        }, out var exception, out elapsed, actionName, logPerformance) && exception != null)
+        {
+            FaultDataflowBlock(actionName, block, exception);
+        }
+    }
+
+    protected void RunActionBlock<T>(IDataflowBlock block, T param, Action<T, CancellationToken> action, [CallerMemberName] string? actionName = null, bool logPerformance = true)
     {
         if (!TryRunAction(() =>
         {
             ThrowIfCancellationRequested();
             action.Invoke(param, Token);
 
-        }, out var exception, actionName, logPerformance) && exception != null)
+        }, out var exception, out var elapsed, actionName, logPerformance) && exception != null)
         {
             FaultDataflowBlock(actionName, block, exception);
         }

--- a/Server/Rubberduck.Parsing/_v3/Pipeline/Abstract/WorkspaceDocumentSection.cs
+++ b/Server/Rubberduck.Parsing/_v3/Pipeline/Abstract/WorkspaceDocumentSection.cs
@@ -28,7 +28,7 @@ public abstract class WorkspaceDocumentSection : DataflowPipelineSection<Workspa
     private TransformBlock<WorkspaceFileUri, DocumentParserState> AcquireDocumentStateBlock { get; set; } = null!;
     private DocumentParserState AcquireDocumentState(WorkspaceFileUri uri)
     {
-        var workspace = _workspaceService.State.GetWorkspace(uri.WorkspaceRoot);
+        var workspace = _workspaceService.State.GetWorkspace(uri);
         if (workspace.TryGetWorkspaceFile(uri, out var state) && state != null)
         {
             State = new DocumentParserState((SourceFileDocumentState)state);

--- a/Server/Rubberduck.Parsing/_v3/Pipeline/Abstract/WorkspaceDocumentSection.cs
+++ b/Server/Rubberduck.Parsing/_v3/Pipeline/Abstract/WorkspaceDocumentSection.cs
@@ -17,6 +17,7 @@ namespace Rubberduck.Parsing._v3.Pipeline.Abstract;
 public abstract class WorkspaceDocumentSection : DataflowPipelineSection<WorkspaceFileUri, DocumentParserState>
 {
     private readonly IWorkspaceService _workspaceService;
+    private IWorkspaceState _workspace = null!;
 
     protected WorkspaceDocumentSection(DataflowPipeline parent, IWorkspaceService workspaceService,
         ILogger<WorkspaceDocumentParserOrchestrator> logger, RubberduckSettingsProvider settingsProvider, PerformanceRecordAggregator performance)
@@ -25,13 +26,15 @@ public abstract class WorkspaceDocumentSection : DataflowPipelineSection<Workspa
         _workspaceService = workspaceService;
     }
 
+    protected void UpdateDocumentState(DocumentParserState state) => _workspace.LoadWorkspaceFile(state);
+
     private TransformBlock<WorkspaceFileUri, DocumentParserState> AcquireDocumentStateBlock { get; set; } = null!;
     private DocumentParserState AcquireDocumentState(WorkspaceFileUri uri)
     {
-        var workspace = _workspaceService.State.GetWorkspace(uri);
+        var workspace = _workspace = _workspaceService.State.GetWorkspace(uri);
         if (workspace.TryGetWorkspaceFile(uri, out var state) && state != null)
         {
-            State = new DocumentParserState((SourceFileDocumentState)state);
+            State = state is DocumentParserState parserState ? parserState : new DocumentParserState(state);
             return State;
         }
 

--- a/Server/Rubberduck.Parsing/_v3/Pipeline/Abstract/WorkspaceOrchestratorSection.cs
+++ b/Server/Rubberduck.Parsing/_v3/Pipeline/Abstract/WorkspaceOrchestratorSection.cs
@@ -31,7 +31,7 @@ public abstract class WorkspaceOrchestratorSection : DataflowPipelineSection<Wor
     private TransformBlock<WorkspaceUri, IWorkspaceState> AcquireWorkspaceBlock { get; set; } = null!;
     private IWorkspaceState AcquireWorkspaceState(WorkspaceUri uri) =>
         RunTransformBlock(AcquireWorkspaceBlock, uri, 
-            e => State = _workspaces.GetWorkspace(uri.WorkspaceRoot) ?? throw new InvalidOperationException($"Could not find workspace state for URI '{uri}'."),
+            e => State = _workspaces.GetWorkspace(uri) ?? throw new InvalidOperationException($"Could not find workspace state for URI '{uri}'."),
             nameof(AcquireWorkspaceState), logPerformance: false);
 
     private TransformManyBlock<IWorkspaceState, WorkspaceFileUri> PrioritizeFilesBlock { get; set; } = null!;

--- a/Server/Rubberduck.Parsing/_v3/Pipeline/Abstract/WorkspaceOrchestratorSection.cs
+++ b/Server/Rubberduck.Parsing/_v3/Pipeline/Abstract/WorkspaceOrchestratorSection.cs
@@ -108,7 +108,11 @@ public abstract class WorkspaceOrchestratorSection : DataflowPipelineSection<Wor
 
         foreach (var (name, block) in DataflowBlocks)
         {
-            builder.AppendLine($"\t{(block.Completion.IsCompletedSuccessfully ? "✔️" : block.Completion.IsFaulted ? "💀" : block.Completion.IsCanceled ? "⚠️" : "◼️")}[{name}] status: {block.Completion.Status}");
+            builder.AppendLine($"\t{(
+                    block.Completion.IsCompletedSuccessfully 
+                    ? "✔️" : block.Completion.IsFaulted 
+                    ? "💀" : block.Completion.IsCanceled 
+                    ? "⚠️" : "◼️")}[{name}] status: {block.Completion.Status}");
         }
         LogDebug(builder.ToString());
     }

--- a/Server/Rubberduck.Parsing/_v3/Pipeline/Abstract/WorkspaceOrchestratorSection.cs
+++ b/Server/Rubberduck.Parsing/_v3/Pipeline/Abstract/WorkspaceOrchestratorSection.cs
@@ -31,7 +31,7 @@ public abstract class WorkspaceOrchestratorSection : DataflowPipelineSection<Wor
     private TransformBlock<WorkspaceUri, IWorkspaceState> AcquireWorkspaceStateBlock { get; set; } = null!;
     private IWorkspaceState AcquireWorkspaceState(WorkspaceUri uri) =>
         RunTransformBlock(AcquireWorkspaceStateBlock, uri, 
-            e => State = _workspaces.GetWorkspace(uri) ?? throw new InvalidOperationException($"Could not find workspace state for URI '{uri}'."),
+            e => State = _workspaces.GetWorkspace(uri.WorkspaceRoot) ?? throw new InvalidOperationException($"Could not find workspace state for URI '{uri}'."),
             nameof(AcquireWorkspaceStateBlock), logPerformance: false);
 
     private TransformManyBlock<IWorkspaceState, WorkspaceFileUri> PrioritizeFilesBlock { get; set; } = null!;

--- a/Server/Rubberduck.Parsing/_v3/Pipeline/Abstract/WorkspaceOrchestratorSection.cs
+++ b/Server/Rubberduck.Parsing/_v3/Pipeline/Abstract/WorkspaceOrchestratorSection.cs
@@ -28,11 +28,11 @@ public abstract class WorkspaceOrchestratorSection : DataflowPipelineSection<Wor
 
     protected abstract WorkspaceDocumentSection StartDocumentPipeline(ParserPipelineSectionProvider provider, WorkspaceFileUri uri);
 
-    private TransformBlock<WorkspaceUri, IWorkspaceState> AcquireWorkspaceBlock { get; set; } = null!;
+    private TransformBlock<WorkspaceUri, IWorkspaceState> AcquireWorkspaceStateBlock { get; set; } = null!;
     private IWorkspaceState AcquireWorkspaceState(WorkspaceUri uri) =>
-        RunTransformBlock(AcquireWorkspaceBlock, uri, 
+        RunTransformBlock(AcquireWorkspaceStateBlock, uri, 
             e => State = _workspaces.GetWorkspace(uri) ?? throw new InvalidOperationException($"Could not find workspace state for URI '{uri}'."),
-            nameof(AcquireWorkspaceState), logPerformance: false);
+            nameof(AcquireWorkspaceStateBlock), logPerformance: false);
 
     private TransformManyBlock<IWorkspaceState, WorkspaceFileUri> PrioritizeFilesBlock { get; set; } = null!;
     private WorkspaceFileUri[] PrioritizeFiles(IWorkspaceState state) =>
@@ -49,7 +49,7 @@ public abstract class WorkspaceOrchestratorSection : DataflowPipelineSection<Wor
             }
 
             return result;
-        }, nameof(PrioritizeFiles), logPerformance: true);
+        }, nameof(PrioritizeFilesBlock), logPerformance: true);
 
     private ActionBlock<WorkspaceDocumentSection> AcquireWorkspaceFilePipelineBlock { get; set; } = null!;
 
@@ -61,23 +61,23 @@ public abstract class WorkspaceOrchestratorSection : DataflowPipelineSection<Wor
                 throw new InvalidOperationException("Child pipeline completion task is unexpectely null.");
             }
             return pipeline.Completion;
-        }, nameof(AcquireWorkspaceFilePipelineAsync), logPerformance: false);
+        }, nameof(AcquireWorkspaceFilePipelineBlock), logPerformance: false);
 
     private TransformBlock<WorkspaceFileUri, WorkspaceDocumentSection> CreateWorkspaceFilePipelineBlock { get; set; } = null!;
     private WorkspaceDocumentSection CreateWorkspaceFilePipeline(WorkspaceFileUri uri) =>
         RunTransformBlock(CreateWorkspaceFilePipelineBlock, uri, e => StartDocumentPipeline(_provider, uri), 
-            nameof(CreateWorkspaceFilePipeline), logPerformance: false);
+            nameof(CreateWorkspaceFilePipelineBlock), logPerformance: false);
 
     protected override (IEnumerable<IDataflowBlock>, Task) DefineSectionBlocks(CancellationTokenSource? tokenSource)
     {
         TokenSource = tokenSource;
 
-        AcquireWorkspaceBlock = new(AcquireWorkspaceState, ConcurrentExecutionOptions(Token));
+        AcquireWorkspaceStateBlock = new(AcquireWorkspaceState, ConcurrentExecutionOptions(Token));
         PrioritizeFilesBlock = new(PrioritizeFiles, ConcurrentExecutionOptions(Token));
         CreateWorkspaceFilePipelineBlock = new(CreateWorkspaceFilePipeline, ConcurrentExecutionOptions(Token));
         AcquireWorkspaceFilePipelineBlock = new(AcquireWorkspaceFilePipelineAsync, ConcurrentExecutionOptions(Token));
 
-        Link(AcquireWorkspaceBlock, PrioritizeFilesBlock);
+        Link(AcquireWorkspaceStateBlock, PrioritizeFilesBlock);
         Link(PrioritizeFilesBlock, CreateWorkspaceFilePipelineBlock);
         Link(CreateWorkspaceFilePipelineBlock, AcquireWorkspaceFilePipelineBlock);
 
@@ -85,35 +85,27 @@ public abstract class WorkspaceOrchestratorSection : DataflowPipelineSection<Wor
 
         return (new IDataflowBlock[]
         {
-            AcquireWorkspaceBlock,
+            AcquireWorkspaceStateBlock,
             PrioritizeFilesBlock,
             CreateWorkspaceFilePipelineBlock,
             AcquireWorkspaceFilePipelineBlock,
         }, Completion);
     }
 
-    protected override ImmutableArray<(string Name, IDataflowBlock Block)> DataflowBlocks => new (string, IDataflowBlock)[]
+    protected override Dictionary<string, IDataflowBlock> DataflowBlocks => new()
     {
-        (nameof(AcquireWorkspaceBlock), AcquireWorkspaceBlock),
-        (nameof(PrioritizeFilesBlock), PrioritizeFilesBlock),
-        (nameof(CreateWorkspaceFilePipelineBlock), CreateWorkspaceFilePipelineBlock),
-        (nameof(AcquireWorkspaceFilePipelineBlock), AcquireWorkspaceFilePipelineBlock),
-    }.ToImmutableArray();
+        [nameof(AcquireWorkspaceStateBlock)] = AcquireWorkspaceStateBlock,
+        [nameof(PrioritizeFilesBlock)] = PrioritizeFilesBlock,
+        [nameof(CreateWorkspaceFilePipelineBlock)] = CreateWorkspaceFilePipelineBlock,
+        [nameof(AcquireWorkspaceFilePipelineBlock)] = AcquireWorkspaceFilePipelineBlock,
+    };
 
-    public override void LogPipelineCompletionState()
+    protected override void LogAdditionalPipelineSectionCompletionInfo(StringBuilder builder, string name)
     {
-        var builder = new StringBuilder();
-        builder.AppendLine($"Pipeline ({GetType().Name}) completion status");
-        builder.AppendLine($"\tℹ️ {(State?.WorkspaceRoot?.ToString() ?? ("(no info)"))}");
-
-        foreach (var (name, block) in DataflowBlocks)
+        var info = State?.WorkspaceRoot?.ToString();
+        if (!string.IsNullOrWhiteSpace(info))
         {
-            builder.AppendLine($"\t{(
-                    block.Completion.IsCompletedSuccessfully 
-                    ? "✔️" : block.Completion.IsFaulted 
-                    ? "💀" : block.Completion.IsCanceled 
-                    ? "⚠️" : "◼️")}[{name}] status: {block.Completion.Status}");
+            builder.AppendLine($"\t📁 {info}");
         }
-        LogDebug(builder.ToString());
     }
 }

--- a/Server/Rubberduck.Parsing/_v3/Pipeline/DocumentHierarchicalSymbolsSection.cs
+++ b/Server/Rubberduck.Parsing/_v3/Pipeline/DocumentHierarchicalSymbolsSection.cs
@@ -46,12 +46,15 @@ public class DocumentHierarchicalSymbolsSection : WorkspaceDocumentSection
         DiscoverHierarchicalSymbolsBlock = new(ResolveMemberSymbols, ConcurrentExecutionOptions(Token));
         _ = TraceBlockCompletionAsync(nameof(DiscoverHierarchicalSymbolsBlock), DiscoverHierarchicalSymbolsBlock);
 
+        var symbolsBuffer = new BufferBlock<Symbol>(new DataflowBlockOptions { CancellationToken = Token });
+
         SetDocumentStateMemberSymbolsBlock = new(SetDocumentStateMemberSymbols, ConcurrentExecutionOptions(Token));
-        var completion = TraceBlockCompletionAsync(nameof(SetDocumentStateMemberSymbolsBlock), SetDocumentStateMemberSymbolsBlock);
+        _ = TraceBlockCompletionAsync(nameof(SetDocumentStateMemberSymbolsBlock), SetDocumentStateMemberSymbolsBlock);
 
         Link(source, AcquireDocumentStateSymbolsBlock);
         Link(AcquireDocumentStateSymbolsBlock, DiscoverHierarchicalSymbolsBlock);
-        Link(DiscoverHierarchicalSymbolsBlock, SetDocumentStateMemberSymbolsBlock);
+        Link(DiscoverHierarchicalSymbolsBlock, symbolsBuffer);
+        Link(symbolsBuffer, SetDocumentStateMemberSymbolsBlock);
 
         return (new IDataflowBlock[] 
         {

--- a/Server/Rubberduck.Parsing/_v3/Pipeline/DocumentHierarchicalSymbolsSection.cs
+++ b/Server/Rubberduck.Parsing/_v3/Pipeline/DocumentHierarchicalSymbolsSection.cs
@@ -61,7 +61,7 @@ public class DocumentHierarchicalSymbolsSection : WorkspaceDocumentSection
             AcquireDocumentStateSymbolsBlock, 
             DiscoverHierarchicalSymbolsBlock,
             SetDocumentStateMemberSymbolsBlock
-        }, completion);
+        }, Completion);
     }
 
     protected override ImmutableArray<(string, IDataflowBlock)> DataflowBlocks => new (string, IDataflowBlock)[]

--- a/Server/Rubberduck.Parsing/_v3/Pipeline/DocumentMemberSymbolsSection.cs
+++ b/Server/Rubberduck.Parsing/_v3/Pipeline/DocumentMemberSymbolsSection.cs
@@ -24,8 +24,8 @@ public class DocumentMemberSymbolsSection : WorkspaceDocumentSection
         _symbolsService = symbolsService;
     }
 
-    private TransformBlock<SourceFileDocumentState, Symbol> AcquireDocumentStateSymbolsBlock { get; set; } = null!;
-    private Symbol AcquireDocumentStateSymbols(SourceFileDocumentState state) =>
+    private TransformBlock<DocumentState, Symbol> AcquireDocumentStateSymbolsBlock { get; set; } = null!;
+    private Symbol AcquireDocumentStateSymbols(DocumentState state) =>
         RunTransformBlock(AcquireDocumentStateSymbolsBlock, state, 
             e => e.Symbol ?? throw new InvalidOperationException("Document.Symbol is unexpectedly null."), 
             nameof(AcquireDocumentStateSymbolsBlock), logPerformance: false);

--- a/Server/Rubberduck.Parsing/_v3/Pipeline/DocumentMemberSymbolsSection.cs
+++ b/Server/Rubberduck.Parsing/_v3/Pipeline/DocumentMemberSymbolsSection.cs
@@ -5,6 +5,8 @@ using Rubberduck.InternalApi.ServerPlatform.LanguageServer;
 using Rubberduck.InternalApi.Services;
 using Rubberduck.InternalApi.Settings;
 using Rubberduck.Parsing._v3.Pipeline.Abstract;
+using System;
+using System.Collections.Concurrent;
 using System.Collections.Immutable;
 using System.Text;
 using System.Threading.Tasks.Dataflow;
@@ -26,22 +28,23 @@ public class DocumentMemberSymbolsSection : WorkspaceDocumentSection
     private Symbol AcquireDocumentStateSymbols(SourceFileDocumentState state) =>
         RunTransformBlock(AcquireDocumentStateSymbolsBlock, state, 
             e => e.Symbol ?? throw new InvalidOperationException("Document.Symbol is unexpectedly null."), 
-            nameof(AcquireDocumentStateSymbols), logPerformance: false);
+            nameof(AcquireDocumentStateSymbolsBlock), logPerformance: false);
 
     private TransformBlock<Symbol, Symbol> ResolveMemberSymbolsBlock { get; set; } = null!;
     private Symbol ResolveMemberSymbols(Symbol symbol) =>
         RunTransformBlock(ResolveMemberSymbolsBlock, symbol, 
             e => _symbolsService.RecursivelyResolveSymbols(e), 
-            nameof(ResolveMemberSymbols), logPerformance: true);
+            nameof(ResolveMemberSymbolsBlock), logPerformance: true);
 
     private ActionBlock<Symbol> SetDocumentStateMemberSymbolsBlock { get; set; } = null!;
     private void SetDocumentStateMemberSymbols(Symbol symbol) =>
         RunActionBlock(SetDocumentStateMemberSymbolsBlock, symbol, 
             e => State = (DocumentParserState)State.WithSymbol(e),
-            nameof(SetDocumentStateMemberSymbols), logPerformance: false);
+            nameof(SetDocumentStateMemberSymbolsBlock), logPerformance: false);
 
     protected override (IEnumerable<IDataflowBlock>, Task) DefineSectionBlocks(ISourceBlock<DocumentParserState> source)
     {
+
         AcquireDocumentStateSymbolsBlock = new(AcquireDocumentStateSymbols, ConcurrentExecutionOptions(Token));
         _ = TraceBlockCompletionAsync(nameof(AcquireDocumentStateSymbolsBlock), AcquireDocumentStateSymbolsBlock);
 
@@ -51,9 +54,9 @@ public class DocumentMemberSymbolsSection : WorkspaceDocumentSection
         var symbolBuffer = new BufferBlock<Symbol>(new DataflowBlockOptions { CancellationToken = Token });
 
         SetDocumentStateMemberSymbolsBlock = new(SetDocumentStateMemberSymbols, SingleMessageExecutionOptions(Token)); // NOTE: not thread-safe, keep single-threaded
-        _ = TraceBlockCompletionAsync(nameof(SetDocumentStateMemberSymbolsBlock), SetDocumentStateMemberSymbolsBlock);
+        Completion = TraceBlockCompletionAsync(nameof(SetDocumentStateMemberSymbolsBlock), SetDocumentStateMemberSymbolsBlock);
 
-        Completion = SetDocumentStateMemberSymbolsBlock.Completion;
+        //Completion = SetDocumentStateMemberSymbolsBlock.Completion;
 
         Link(source, AcquireDocumentStateSymbolsBlock);
         Link(AcquireDocumentStateSymbolsBlock, ResolveMemberSymbolsBlock);
@@ -67,23 +70,19 @@ public class DocumentMemberSymbolsSection : WorkspaceDocumentSection
             }, Completion);
     }
 
-    protected override ImmutableArray<(string, IDataflowBlock)> DataflowBlocks => new (string, IDataflowBlock)[]
+    protected override Dictionary<string, IDataflowBlock> DataflowBlocks => new()
     {
-        (nameof(AcquireDocumentStateSymbolsBlock), AcquireDocumentStateSymbolsBlock),
-        (nameof(ResolveMemberSymbolsBlock), ResolveMemberSymbolsBlock),
-        (nameof(SetDocumentStateMemberSymbolsBlock), SetDocumentStateMemberSymbolsBlock),
-    }.ToImmutableArray();
+        [nameof(AcquireDocumentStateSymbolsBlock)] = AcquireDocumentStateSymbolsBlock,
+        [nameof(ResolveMemberSymbolsBlock)] = ResolveMemberSymbolsBlock,
+        [nameof(SetDocumentStateMemberSymbolsBlock)] = SetDocumentStateMemberSymbolsBlock,
+    };
 
-    public override void LogPipelineCompletionState()
+    protected override void LogAdditionalPipelineSectionCompletionInfo(StringBuilder builder, string name)
     {
-        var builder = new StringBuilder();
-        builder.AppendLine($"Pipeline ({GetType().Name}) completion status");
-        builder.AppendLine($"\tℹ️ {(State?.Uri.ToString() ?? ("(no info)"))}");
-
-        foreach (var (name, block) in DataflowBlocks)
+        var uri = State?.Uri?.ToString();
+        if (State != null && !string.IsNullOrWhiteSpace(uri))
         {
-            builder.AppendLine($"\t{(block.Completion.IsCompletedSuccessfully ? "✔️" : block.Completion.IsFaulted ? "💀" : block.Completion.IsCanceled ? "⚠️" : "◼️")}[{name}] status: {block.Completion.Status}");
+            builder.AppendLine($"\t📂 Uri: {uri} (⛔{State.SyntaxErrors.Count} errors; ⚠️{State.Diagnostics.Count} diagnostics; 🧩{State.Symbol?.Children?.Count() ?? 0} child symbols)");
         }
-        LogDebug(builder.ToString());
     }
 }

--- a/Server/Rubberduck.Parsing/_v3/Pipeline/DocumentParserSection.cs
+++ b/Server/Rubberduck.Parsing/_v3/Pipeline/DocumentParserSection.cs
@@ -5,6 +5,7 @@ using Rubberduck.InternalApi.ServerPlatform.LanguageServer;
 using Rubberduck.InternalApi.Services;
 using Rubberduck.InternalApi.Settings;
 using Rubberduck.Parsing._v3.Pipeline.Abstract;
+using System.Collections.Concurrent;
 using System.Collections.Immutable;
 using System.Text;
 using System.Threading.Tasks.Dataflow;
@@ -27,46 +28,50 @@ public class DocumentParserSection : WorkspaceDocumentSection
     private TransformBlock<DocumentState, PipelineParseResult> ParseDocumentTextBlock { get; set; } = null!;
     private PipelineParseResult ParseDocumentText(DocumentState documentState) =>
         RunTransformBlock(ParseDocumentTextBlock, documentState, 
-            e => _parser.ParseDocument(e, Token), nameof(ParseDocumentText), logPerformance: true);
+            e => _parser.ParseDocument(e, Token), 
+            nameof(ParseDocumentTextBlock), logPerformance: true);
 
     private BroadcastBlock<PipelineParseResult> BroadcastParseResultBlock { get; set; } = null!;
     private PipelineParseResult BroadcastParseResult(PipelineParseResult parseResult) =>
         RunTransformBlock(BroadcastParseResultBlock, parseResult, 
-            e => e, nameof(BroadcastParseResult), logPerformance: false);
+            e => e, 
+            nameof(BroadcastParseResultBlock), logPerformance: false);
 
     private ActionBlock<PipelineParseResult> SetDocumentStateFoldingsBlock { get; set; } = null!;
     private void SetDocumentStateFoldings(PipelineParseResult parseResult) =>
         RunActionBlock(SetDocumentStateFoldingsBlock, parseResult, 
             e => State = (DocumentParserState)State.WithFoldings(e.Foldings) ?? throw new InvalidOperationException("Document state was unexpectedly null."),
-            nameof(SetDocumentStateFoldings), logPerformance: false);
+            nameof(SetDocumentStateFoldingsBlock), logPerformance: false);
 
     private TransformBlock<PipelineParseResult, IParseTree> AcquireSyntaxTreeBlock { get; set; } = null!;
     private IParseTree AcquireSyntaxTree(PipelineParseResult input) =>
         RunTransformBlock(AcquireSyntaxTreeBlock, input, 
-            e => e.ParseResult.Tree, nameof(AcquireSyntaxTree), logPerformance: false);
+            e => e.ParseResult.Tree, 
+            nameof(AcquireSyntaxTreeBlock), logPerformance: false);
 
     private BroadcastBlock<IParseTree> BroadcastSyntaxTreeBlock { get; set; } = null!;
     private IParseTree BroadcastSyntaxTree(IParseTree syntaxTree) =>
         RunTransformBlock(BroadcastSyntaxTreeBlock, syntaxTree, 
-            e => e, nameof(BroadcastSyntaxTree), logPerformance: false);
+            e => e, 
+            nameof(BroadcastSyntaxTreeBlock), logPerformance: false);
 
     private ActionBlock<IParseTree> SetDocumentStateSyntaxTreeBlock { get; set; } = null!;
     private void SetDocumentStateSyntaxTree(IParseTree syntaxTree) =>
         RunActionBlock(SetDocumentStateSyntaxTreeBlock, syntaxTree, 
             e => State = State.WithSyntaxTree(e), 
-            nameof(SetDocumentStateSyntaxTree), logPerformance: false);
+            nameof(SetDocumentStateSyntaxTreeBlock), logPerformance: false);
 
     private TransformBlock<IParseTree, Symbol> DiscoverMemberSymbolsBlock { get; set; } = null!;
     private Symbol DiscoverMemberSymbols(IParseTree syntaxTree) =>
         RunTransformBlock(DiscoverMemberSymbolsBlock, syntaxTree, 
             e => _symbolsService.DiscoverMemberSymbols(syntaxTree, State.Uri),
-            nameof(DiscoverMemberSymbols), logPerformance: true);
+            nameof(DiscoverMemberSymbolsBlock), logPerformance: true);
 
     private ActionBlock<Symbol> SetDocumentStateMemberSymbolsBlock { get; set; } = null!;
     private void SetDocumentStateMemberSymbols(Symbol symbol) =>
         RunActionBlock(SetDocumentStateMemberSymbolsBlock, symbol, 
             e => State = (DocumentParserState)State.WithSymbol(e),
-            nameof(SetDocumentStateMemberSymbols), logPerformance: false);
+            nameof(SetDocumentStateMemberSymbolsBlock), logPerformance: false);
 
     protected override (IEnumerable<IDataflowBlock>, Task) DefineSectionBlocks(ISourceBlock<DocumentParserState> source)
     {
@@ -95,7 +100,8 @@ public class DocumentParserSection : WorkspaceDocumentSection
         DiscoverMemberSymbolsBlock = new(DiscoverMemberSymbols, ConcurrentExecutionOptions(Token));
         _ = TraceBlockCompletionAsync(nameof(DiscoverMemberSymbolsBlock), DiscoverMemberSymbolsBlock);
 
-        var symbolsBufferBlock = new BufferBlock<Symbol>(new DataflowBlockOptions { CancellationToken = Token });
+        var SymbolsBufferBlock = new BufferBlock<Symbol>(new DataflowBlockOptions { CancellationToken = Token });
+        _ = TraceBlockCompletionAsync(nameof(SymbolsBufferBlock), SymbolsBufferBlock);
 
         SetDocumentStateMemberSymbolsBlock = new(SetDocumentStateMemberSymbols, SingleMessageExecutionOptions(Token)); // NOTE: not thread-safe, keep single-threaded
         _ = TraceBlockCompletionAsync(nameof(SetDocumentStateMemberSymbolsBlock), SetDocumentStateMemberSymbolsBlock);
@@ -113,10 +119,10 @@ public class DocumentParserSection : WorkspaceDocumentSection
 
         Link(syntaxTreeBufferBlock, SetDocumentStateSyntaxTreeBlock);
 
-        Link(DiscoverMemberSymbolsBlock, symbolsBufferBlock);
-        Link(symbolsBufferBlock, SetDocumentStateMemberSymbolsBlock);
+        Link(DiscoverMemberSymbolsBlock, SymbolsBufferBlock);
+        Link(SymbolsBufferBlock, SetDocumentStateMemberSymbolsBlock);
 
-        var completion = Task.WhenAll(DataflowBlocks.Select(e => e.Block.Completion).ToArray());
+        var completion = Task.WhenAll(DataflowBlocks.Values.Select(e => e.Completion).ToArray());
 
         return (new IDataflowBlock[]{
             ParseDocumentTextBlock,
@@ -130,28 +136,24 @@ public class DocumentParserSection : WorkspaceDocumentSection
         }, completion);
     }
 
-    protected override ImmutableArray<(string Name, IDataflowBlock Block)> DataflowBlocks => new (string, IDataflowBlock)[]
+    protected override Dictionary<string, IDataflowBlock> DataflowBlocks => new()
     {
-        (nameof(ParseDocumentTextBlock), ParseDocumentTextBlock),
-        (nameof(BroadcastParseResultBlock), BroadcastParseResultBlock),
-        (nameof(SetDocumentStateFoldingsBlock), SetDocumentStateFoldingsBlock),
-        (nameof(AcquireSyntaxTreeBlock), AcquireSyntaxTreeBlock),
-        (nameof(BroadcastSyntaxTreeBlock), BroadcastSyntaxTreeBlock),
-        (nameof(SetDocumentStateMemberSymbolsBlock), SetDocumentStateMemberSymbolsBlock),
-        (nameof(DiscoverMemberSymbolsBlock), DiscoverMemberSymbolsBlock),
-        (nameof(SetDocumentStateSyntaxTreeBlock), SetDocumentStateSyntaxTreeBlock),
-    }.ToImmutableArray();
+        [nameof(ParseDocumentTextBlock)] = ParseDocumentTextBlock,
+        [nameof(BroadcastParseResultBlock)] = BroadcastParseResultBlock,
+        [nameof(SetDocumentStateFoldingsBlock)] = SetDocumentStateFoldingsBlock,
+        [nameof(AcquireSyntaxTreeBlock)] = AcquireSyntaxTreeBlock,
+        [nameof(BroadcastSyntaxTreeBlock)] = BroadcastSyntaxTreeBlock,
+        [nameof(SetDocumentStateMemberSymbolsBlock)] = SetDocumentStateMemberSymbolsBlock,
+        [nameof(DiscoverMemberSymbolsBlock)] = DiscoverMemberSymbolsBlock,
+        [nameof(SetDocumentStateSyntaxTreeBlock)] = SetDocumentStateSyntaxTreeBlock,
+    };
 
-    public override void LogPipelineCompletionState()
+    protected override void LogAdditionalPipelineSectionCompletionInfo(StringBuilder builder, string name)
     {
-        var builder = new StringBuilder();
-        builder.AppendLine($"Pipeline ({GetType().Name}) completion status");
-        builder.AppendLine($"\tℹ️ {(State?.Uri.ToString() ?? ("(no info)"))}");
-
-        foreach (var (name, block) in DataflowBlocks)
+        var uri = State?.Uri;
+        if (State != null && !string.IsNullOrWhiteSpace(uri?.ToString()))
         {
-            builder.AppendLine($"\t{(block.Completion.IsCompletedSuccessfully ? "✔️" : block.Completion.IsFaulted ? "💀" : block.Completion.IsCanceled ? "⚠️" : "◼️")}[{name}] status: {block.Completion.Status}");
+            builder.AppendLine($"\t📂 Uri: {uri} (⛔{State.SyntaxErrors.Count} errors; ⚠️{State.Diagnostics.Count} diagnostics; 🧩{State.Symbol?.Children?.Count() ?? 0} child symbols)");
         }
-        LogDebug(builder.ToString());
     }
 }

--- a/Server/Rubberduck.Parsing/_v3/Pipeline/Services/DocumentParserState.cs
+++ b/Server/Rubberduck.Parsing/_v3/Pipeline/Services/DocumentParserState.cs
@@ -1,17 +1,30 @@
 ﻿using Antlr4.Runtime.Tree;
+using Rubberduck.InternalApi.Extensions;
 using Rubberduck.InternalApi.Model.Declarations.Symbols;
 using Rubberduck.InternalApi.ServerPlatform.LanguageServer;
 
 namespace Rubberduck.Parsing._v3.Pipeline;
 
-public record class DocumentParserState : SourceFileDocumentState
+public record class DocumentParserState : DocumentState
 {
-    public DocumentParserState(SourceFileDocumentState original)
+    public DocumentParserState(DocumentState original)
         : base(original)
+    {
+    }
+
+    public DocumentParserState(DocumentParserState original)
+        : base(original)
+    {
+        SyntaxTree = original.SyntaxTree;
+    }
+
+    public DocumentParserState(WorkspaceFileUri uri, string text, int version = 1, bool isOpened = false) 
+        : base(uri, text, version, isOpened)
     {
     }
 
     public IParseTree? SyntaxTree { get; init; }
 
     public DocumentParserState WithSyntaxTree(IParseTree tree) => this with { SyntaxTree = tree };
+    public new DocumentParserState WithSymbol(Symbol module) => this with { Symbol = module };
 }

--- a/Server/Rubberduck.Parsing/_v3/Pipeline/Services/LibrarySymbolsService.cs
+++ b/Server/Rubberduck.Parsing/_v3/Pipeline/Services/LibrarySymbolsService.cs
@@ -33,7 +33,7 @@ public class LibrarySymbolsService : ServiceBase
             throw new InvalidOperationException($"Could not load referenced type library '{reference.Name}' ({reference.Uri}).");
         }
 
-        var project = new ComProject(typeLib, uri);
-        return (ProjectSymbol)project.ToSymbol();
+        var project = new ComProject(typeLib, uri).ToSymbol();
+        return (ProjectSymbol)project;
     }
 }

--- a/Server/Rubberduck.Parsing/_v3/Pipeline/Services/LibrarySymbolsService.cs
+++ b/Server/Rubberduck.Parsing/_v3/Pipeline/Services/LibrarySymbolsService.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.Extensions.Logging;
+using Rubberduck.InternalApi.Model.Declarations.Symbols;
+using Rubberduck.InternalApi.Model.Workspace;
+using Rubberduck.InternalApi.Services;
+using Rubberduck.InternalApi.Settings;
+using Rubberduck.Parsing.COM.Abstract;
+using Rubberduck.Parsing.Model.ComReflection;
+
+namespace Rubberduck.Parsing._v3.Pipeline;
+
+public class LibrarySymbolsService : ServiceBase
+{
+    private readonly IComLibraryProvider _comLibraryProvider;
+
+    public LibrarySymbolsService(IComLibraryProvider comLibraryProvider,
+        ILogger<LibrarySymbolsService> logger, RubberduckSettingsProvider settingsProvider, PerformanceRecordAggregator performance) 
+        : base(logger, settingsProvider, performance)
+    {
+        _comLibraryProvider = comLibraryProvider;
+    }
+
+    public ProjectSymbol LoadSymbolsFromTypeLibrary(Reference reference)
+    {
+        var uri = reference.Uri;
+        if (string.IsNullOrWhiteSpace(uri))
+        {
+            throw new InvalidOperationException("Uri cannot be null or empty.");
+        }
+
+        var typeLib = _comLibraryProvider.LoadTypeLibrary(uri);
+        if (typeLib is null)
+        {
+            throw new InvalidOperationException($"Could not load referenced type library '{reference.Name}' ({reference.Uri}).");
+        }
+
+        var project = new ComProject(typeLib, uri);
+        return (ProjectSymbol)project.ToSymbol();
+    }
+}

--- a/Server/Rubberduck.Parsing/_v3/Pipeline/Services/MemberSymbolsListener.cs
+++ b/Server/Rubberduck.Parsing/_v3/Pipeline/Services/MemberSymbolsListener.cs
@@ -412,7 +412,7 @@ public class MemberSymbolsListener : VBAParserBaseListener, IVBListener<Symbol>
     {
         var name = GetIdentifierNameTokenText(context.functionName().identifier());
         var accessibility = GetAccessibility(context.visibility());
-        var typeName = context.asTypeClause()?.GetText();
+        var typeName = GetAsTypeExpressionText(context.asTypeClause());
 
         OnChildSymbol(CreateCurrentSymbol(children => new FunctionSymbol(name, _workspaceFileUri, accessibility, children, typeName), context), context);
     }
@@ -423,7 +423,7 @@ public class MemberSymbolsListener : VBAParserBaseListener, IVBListener<Symbol>
     {
         var name = GetIdentifierNameTokenText(context.functionName().identifier());
         var accessibility = GetAccessibility(context.visibility());
-        var typeName = context.asTypeClause()?.GetText();
+        var typeName = GetAsTypeExpressionText(context.asTypeClause());
 
         OnChildSymbol(CreateCurrentSymbol(children => new PropertyGetSymbol(name, _workspaceFileUri, accessibility, children, typeName), context), context);
     }

--- a/Server/Rubberduck.Parsing/_v3/Pipeline/Services/MemberSymbolsListener.cs
+++ b/Server/Rubberduck.Parsing/_v3/Pipeline/Services/MemberSymbolsListener.cs
@@ -346,7 +346,7 @@ public class MemberSymbolsListener : VBAParserBaseListener, IVBListener<Symbol>
         var name = context.identifier().GetText();
         var accessibility = GetAccessibility(context.visibility());
 
-        OnChildSymbol(CreateCurrentSymbol(children => new EventMemberSymbol(name, _workspaceFileUri, accessibility, children.OfType<ParameterSymbol>()), context), context);
+        OnChildSymbol(CreateCurrentSymbol(children => new EventSymbol(name, _workspaceFileUri, accessibility, children.OfType<ParameterSymbol>()), context), context);
     }
 
     public override void EnterEnumerationStmt([NotNull] VBAParser.EnumerationStmtContext context) => OnEnterNewCurrentSymbol(context);

--- a/Server/Rubberduck.Parsing/_v3/Pipeline/Services/ParserPipelineSectionProvider.cs
+++ b/Server/Rubberduck.Parsing/_v3/Pipeline/Services/ParserPipelineSectionProvider.cs
@@ -70,18 +70,6 @@ public class ParserPipelineSectionProvider
     {
         _ = uri ?? throw new ArgumentNullException(nameof(uri));
 
-        if (_pipelines.TryGetValue(uri, out var pipeline))
-        {
-            try
-            {
-                pipeline.Cancel();
-            }
-            finally
-            {
-                _tasks.Remove(uri, out _);
-            }
-        }
-
         var workspaces = _provider.GetRequiredService<IWorkspaceService>();
         var symbols = _provider.GetRequiredService<PipelineParseTreeSymbolsService>();
         var logger = _provider.GetRequiredService<ILogger<WorkspaceDocumentParserOrchestrator>>();

--- a/Server/Rubberduck.Parsing/_v3/Pipeline/Services/PipelineParserService.cs
+++ b/Server/Rubberduck.Parsing/_v3/Pipeline/Services/PipelineParserService.cs
@@ -2,6 +2,7 @@
 using Rubberduck.Parsing.Abstract;
 using Rubberduck.InternalApi.Settings;
 using Rubberduck.InternalApi.ServerPlatform.LanguageServer;
+using Rubberduck.Parsing.Exceptions;
 
 namespace Rubberduck.Parsing._v3.Pipeline;
 
@@ -10,18 +11,21 @@ public class PipelineParserService
     private readonly RubberduckSettingsProvider _settingsProvider;
     private readonly IParser<string> _parser;
     private readonly IResolverService _resolver;
+    private readonly ISyntaxErrorMessageService _messageService;
 
-    public PipelineParserService(RubberduckSettingsProvider settingsProvider, IParser<string> parser, IResolverService resolver)
+    public PipelineParserService(RubberduckSettingsProvider settingsProvider, IParser<string> parser, ISyntaxErrorMessageService messageService, IResolverService resolver)
     {
         _settingsProvider = settingsProvider;
         _parser = parser;
         _resolver = resolver;
+        _messageService = messageService;
     }
 
     public PipelineParseResult ParseDocument(DocumentState state, CancellationToken token)
     {
         var settings = _settingsProvider.Settings.EditorSettings.CodeFoldingSettings;
         var foldingsListener = new VBFoldingListener(settings);
+        var sllErrorListener = new ReportingSyntaxErrorListener(state.Uri, _messageService);
         
         token.ThrowIfCancellationRequested();
 

--- a/Server/Rubberduck.Parsing/_v3/Pipeline/WorkspacePipeline.cs
+++ b/Server/Rubberduck.Parsing/_v3/Pipeline/WorkspacePipeline.cs
@@ -15,13 +15,13 @@ public class WorkspacePipeline : DataflowPipeline
 {
     private readonly IWorkspaceStateManager _workspaces;
 
-    public WorkspacePipeline(IWorkspaceStateManager workspaces, ParserPipelineSectionProvider sectionProvider,
+    public WorkspacePipeline(IWorkspaceStateManager workspaces, ParserPipelineSectionProvider sectionProvider, LibrarySymbolsService librarySymbols,
         ILogger<WorkspacePipeline> logger, RubberduckSettingsProvider settingsProvider, PerformanceRecordAggregator performance) 
         : base(logger, settingsProvider, performance)
     {
         _workspaces = workspaces;
 
-        ReferencedSymbolsSection = new WorkspaceReferencedSymbolsSection(this, _workspaces, logger, settingsProvider, performance);
+        ReferencedSymbolsSection = new WorkspaceReferencedSymbolsSection(this, _workspaces, librarySymbols, logger, settingsProvider, performance);
         SyntaxOrchestration = new WorkspaceDocumentParserOrchestrator(this, _workspaces, sectionProvider, logger, settingsProvider, performance); 
         MemberSymbolOrchestration = new WorkspaceMemberSymbolsOrchestrator(this, _workspaces, sectionProvider, logger, settingsProvider, performance);
         HierarchicalSymbolOrchestration = new WorkspaceHierarchicalSymbolsOrchestrator(this, _workspaces, sectionProvider, logger, settingsProvider, performance);
@@ -50,19 +50,19 @@ public class WorkspacePipeline : DataflowPipeline
             var uri = (WorkspaceUri)input;
 
             // first collect the symbols from referenced libraries
-            var referencedSymbols = ReferencedSymbolsSection.StartAsync(uri, TokenSource);
+            var referencedSymbols = ReferencedSymbolsSection.StartAsync(uri, tokenSource);
 
             // we collect the syntax trees.
             var syntaxOrchestration = SyntaxOrchestration.StartAsync(uri, null, tokenSource);
 
             // must await completion of referenced symbols and syntax trees before we can resolve symbol types
-            await Task.WhenAll(syntaxOrchestration);
+            await Task.WhenAll(referencedSymbols, syntaxOrchestration);
 
-            // then we can resolve member symbols...
-            await MemberSymbolOrchestration.StartAsync(uri, null, tokenSource);
+            //// then we can resolve member symbols...
+            //await MemberSymbolOrchestration.StartAsync(uri, null, tokenSource);
 
-            // ...and only then we know enough to collect and resolve the rest of the symbols.
-            await HierarchicalSymbolOrchestration.StartAsync(uri, null, tokenSource);
+            //// ...and only then we know enough to collect and resolve the rest of the symbols.
+            //await HierarchicalSymbolOrchestration.StartAsync(uri, null, tokenSource);
 
             LogTrace($"{nameof(WorkspacePipeline)} completed.");
         }, logPerformance: true);

--- a/Server/Rubberduck.Parsing/_v3/Pipeline/WorkspacePipeline.cs
+++ b/Server/Rubberduck.Parsing/_v3/Pipeline/WorkspacePipeline.cs
@@ -59,7 +59,7 @@ public class WorkspacePipeline : DataflowPipeline
             await Task.WhenAll(referencedSymbols, syntaxOrchestration);
 
             //// then we can resolve member symbols...
-            //await MemberSymbolOrchestration.StartAsync(uri, null, tokenSource);
+            await MemberSymbolOrchestration.StartAsync(uri, null, tokenSource);
 
             //// ...and only then we know enough to collect and resolve the rest of the symbols.
             //await HierarchicalSymbolOrchestration.StartAsync(uri, null, tokenSource);

--- a/Server/Rubberduck.Parsing/_v3/Pipeline/WorkspaceReferencedSymbolsSection.cs
+++ b/Server/Rubberduck.Parsing/_v3/Pipeline/WorkspaceReferencedSymbolsSection.cs
@@ -44,7 +44,10 @@ public class WorkspaceReferencedSymbolsSection : DataflowPipelineSection<Workspa
     private ActionBlock<ProjectSymbol> SetLibrarySymbolStateBlock { get; set; } = default!;
     private void SetLibrarySymbolState(ProjectSymbol symbol) =>
         RunActionBlock(SetLibrarySymbolStateBlock, symbol,
-            e => State.ExecutionContext.LoadReferencedLibrarySymbols(symbol),
+            e =>
+            {
+                State.ExecutionContext.LoadReferencedLibrarySymbols(symbol);
+            },
             nameof(SetLibrarySymbolStateBlock), logPerformance: false);
 
 

--- a/Server/Rubberduck.Parsing/_v3/Pipeline/WorkspaceReferencedSymbolsSection.cs
+++ b/Server/Rubberduck.Parsing/_v3/Pipeline/WorkspaceReferencedSymbolsSection.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.Extensions.Logging;
+using Rubberduck.InternalApi.Extensions;
+using Rubberduck.InternalApi.Services;
+using Rubberduck.InternalApi.Settings;
+using Rubberduck.Parsing._v3.Pipeline.Abstract;
+using System.Collections.Immutable;
+using System.Threading.Tasks.Dataflow;
+
+namespace Rubberduck.Parsing._v3.Pipeline;
+
+public class WorkspaceReferencedSymbolsSection : DataflowPipelineSection<WorkspaceUri, IWorkspaceState>
+{
+    private IWorkspaceStateManager _workspaces;
+
+    public WorkspaceReferencedSymbolsSection(DataflowPipeline parent, IWorkspaceStateManager workspaces,
+        ILogger logger, RubberduckSettingsProvider settingsProvider, PerformanceRecordAggregator performance) 
+        : base(parent, logger, settingsProvider, performance)
+    {
+        _workspaces = workspaces;
+    }
+
+    private TransformBlock<WorkspaceUri, IWorkspaceState> AcquireWorkspaceStateBlock { get; set; } = default!;
+    private IWorkspaceState AcquireWorkspaceState(WorkspaceUri uri) =>
+        RunTransformBlock(AcquireWorkspaceStateBlock, uri,
+            e => _workspaces.GetWorkspace(uri),
+            nameof(AcquireWorkspaceState), logPerformance: false);
+
+    
+
+    protected override ImmutableArray<(string Name, IDataflowBlock Block)> DataflowBlocks =>
+        [
+            (nameof(AcquireWorkspaceState), AcquireWorkspaceStateBlock)
+        ];
+
+    protected override (IEnumerable<IDataflowBlock> blocks, Task completion) DefineSectionBlocks(CancellationTokenSource? tokenSource)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/Server/Rubberduck.Parsing/_v3/Pipeline/WorkspaceReferencedSymbolsSection.cs
+++ b/Server/Rubberduck.Parsing/_v3/Pipeline/WorkspaceReferencedSymbolsSection.cs
@@ -1,5 +1,7 @@
 ﻿using Microsoft.Extensions.Logging;
 using Rubberduck.InternalApi.Extensions;
+using Rubberduck.InternalApi.Model.Declarations.Symbols;
+using Rubberduck.InternalApi.Model.Workspace;
 using Rubberduck.InternalApi.Services;
 using Rubberduck.InternalApi.Settings;
 using Rubberduck.Parsing._v3.Pipeline.Abstract;
@@ -11,12 +13,14 @@ namespace Rubberduck.Parsing._v3.Pipeline;
 public class WorkspaceReferencedSymbolsSection : DataflowPipelineSection<WorkspaceUri, IWorkspaceState>
 {
     private IWorkspaceStateManager _workspaces;
+    private readonly LibrarySymbolsService _librarySymbolsService;
 
-    public WorkspaceReferencedSymbolsSection(DataflowPipeline parent, IWorkspaceStateManager workspaces,
+    public WorkspaceReferencedSymbolsSection(DataflowPipeline parent, IWorkspaceStateManager workspaces, LibrarySymbolsService librarySymbolsService,
         ILogger logger, RubberduckSettingsProvider settingsProvider, PerformanceRecordAggregator performance) 
         : base(parent, logger, settingsProvider, performance)
     {
         _workspaces = workspaces;
+        _librarySymbolsService = librarySymbolsService;
     }
 
     private TransformBlock<WorkspaceUri, IWorkspaceState> AcquireWorkspaceStateBlock { get; set; } = default!;
@@ -25,15 +29,57 @@ public class WorkspaceReferencedSymbolsSection : DataflowPipelineSection<Workspa
             e => _workspaces.GetWorkspace(uri),
             nameof(AcquireWorkspaceState), logPerformance: false);
 
-    
+    private TransformManyBlock<IWorkspaceState, Reference> AcquireLibraryReferencesBlock { get; set; } = default!;
+    private IEnumerable<Reference> AcquireLibraryReferences(IWorkspaceState state) =>
+        RunTransformBlock(AcquireLibraryReferencesBlock, state,
+            e => state.References, 
+            nameof(AcquireLibraryReferences), logPerformance: false);
+
+    private TransformBlock<Reference, ProjectSymbol> LoadLibrarySymbolsBlock { get; set; } = default!;
+    private ProjectSymbol LoadLibrarySymbols(Reference reference) =>
+        RunTransformBlock(LoadLibrarySymbolsBlock, reference,
+            e => _librarySymbolsService.LoadSymbolsFromTypeLibrary(reference),
+            nameof(LoadLibrarySymbols), logPerformance: true);
+
+    private ActionBlock<ProjectSymbol> SetLibrarySymbolStateBlock { get; set; } = default!;
+    private void SetLibrarySymbolState(ProjectSymbol symbol) =>
+        RunActionBlock(SetLibrarySymbolStateBlock, symbol,
+            e => State.ExecutionContext.LoadReferencedLibrarySymbols(symbol),
+            nameof(SetLibrarySymbolState), logPerformance: false);
+
 
     protected override ImmutableArray<(string Name, IDataflowBlock Block)> DataflowBlocks =>
         [
-            (nameof(AcquireWorkspaceState), AcquireWorkspaceStateBlock)
+            (nameof(AcquireWorkspaceState), AcquireWorkspaceStateBlock),
+            (nameof(AcquireLibraryReferences), AcquireLibraryReferencesBlock),
+            (nameof(LoadLibrarySymbols), LoadLibrarySymbolsBlock),
+            (nameof(SetLibrarySymbolState), SetLibrarySymbolStateBlock),
         ];
 
     protected override (IEnumerable<IDataflowBlock> blocks, Task completion) DefineSectionBlocks(CancellationTokenSource? tokenSource)
     {
-        throw new NotImplementedException();
+        AcquireWorkspaceStateBlock = new(AcquireWorkspaceState, ConcurrentExecutionOptions(Token));
+        _ = TraceBlockCompletionAsync(nameof(AcquireWorkspaceStateBlock), AcquireWorkspaceStateBlock);
+
+        AcquireLibraryReferencesBlock = new(AcquireLibraryReferences, ConcurrentExecutionOptions(Token));
+        _ = TraceBlockCompletionAsync(nameof(AcquireLibraryReferencesBlock), AcquireLibraryReferencesBlock);
+
+        LoadLibrarySymbolsBlock = new(LoadLibrarySymbols, ConcurrentExecutionOptions(Token));
+        _ = TraceBlockCompletionAsync(nameof(LoadLibrarySymbolsBlock), LoadLibrarySymbolsBlock);
+
+        SetLibrarySymbolStateBlock = new(SetLibrarySymbolState, ConcurrentExecutionOptions(Token));
+        _ = TraceBlockCompletionAsync(nameof(SetLibrarySymbolStateBlock), SetLibrarySymbolStateBlock);
+
+        Link(AcquireWorkspaceStateBlock, AcquireLibraryReferencesBlock);
+        Link(AcquireLibraryReferencesBlock, LoadLibrarySymbolsBlock);
+        Link(LoadLibrarySymbolsBlock, SetLibrarySymbolStateBlock);
+
+        return (
+            [
+                AcquireWorkspaceStateBlock,
+                AcquireLibraryReferencesBlock,
+                LoadLibrarySymbolsBlock,
+                SetLibrarySymbolStateBlock,
+            ], SetLibrarySymbolStateBlock.Completion);
     }
 }

--- a/Server/Rubberduck.Parsing/_v3/Pipeline/WorkspaceReferencedSymbolsSection.cs
+++ b/Server/Rubberduck.Parsing/_v3/Pipeline/WorkspaceReferencedSymbolsSection.cs
@@ -26,7 +26,7 @@ public class WorkspaceReferencedSymbolsSection : DataflowPipelineSection<Workspa
     private TransformBlock<WorkspaceUri, IWorkspaceState> AcquireWorkspaceStateBlock { get; set; } = default!;
     private IWorkspaceState AcquireWorkspaceState(WorkspaceUri uri) =>
         RunTransformBlock(AcquireWorkspaceStateBlock, uri,
-            e => _workspaces.GetWorkspace(uri),
+            e => State = _workspaces.GetWorkspace(uri),
             nameof(AcquireWorkspaceState), logPerformance: false);
 
     private TransformManyBlock<IWorkspaceState, Reference> AcquireLibraryReferencesBlock { get; set; } = default!;

--- a/Shared/Rubberduck.InternalApi/Extensions/LoggerExtensions.cs
+++ b/Shared/Rubberduck.InternalApi/Extensions/LoggerExtensions.cs
@@ -58,7 +58,7 @@ public static class LoggerExtensions
     public static void LogPerformance(this ILogger logger, TraceLevel level, string message, TimeSpan elapsed, LogPerformanceOptions options)
     {
         var logLevel = options.GetLogLevel(elapsed);
-        logger.Log(level, logLevel, message, $"⏱️ {elapsed}");
+        logger.Log(level, logLevel, message, $"⏱️{elapsed}");
     }
 
     /// <summary>

--- a/Shared/Rubberduck.InternalApi/Extensions/LoggerExtensions.cs
+++ b/Shared/Rubberduck.InternalApi/Extensions/LoggerExtensions.cs
@@ -58,7 +58,7 @@ public static class LoggerExtensions
     public static void LogPerformance(this ILogger logger, TraceLevel level, string message, TimeSpan elapsed, LogPerformanceOptions options)
     {
         var logLevel = options.GetLogLevel(elapsed);
-        logger.Log(level, logLevel, message, $"Elapsed: {elapsed}");
+        logger.Log(level, logLevel, message, $"⏱️ {elapsed}");
     }
 
     /// <summary>

--- a/Shared/Rubberduck.InternalApi/Model/Declarations/Execution/VBExecutionContext.cs
+++ b/Shared/Rubberduck.InternalApi/Model/Declarations/Execution/VBExecutionContext.cs
@@ -76,6 +76,11 @@ public class VBExecutionContext : ServiceBase, IDiagnosticSource
     public ImmutableHashSet<TypedSymbol> ResolvedSymbols => _symbols.Keys.Where(e => e.ResolvedType != null).ToImmutableHashSet();
 
     /// <summary>
+    /// Gets all unresolved symbols in the context.
+    /// </summary>
+    public ImmutableHashSet<TypedSymbol> UnresolvedSymbols => _symbols.Keys.Where(e => e.ResolvedType is null).ToImmutableHashSet();
+
+    /// <summary>
     /// Gets all <c>VBMemberOwnerType</c> data types in the context.
     /// </summary>
     public ImmutableHashSet<TypedSymbol> MemberOwnerTypes => _symbols.Keys.Where(e => e.ResolvedType is VBMemberOwnerType).ToImmutableHashSet();

--- a/Shared/Rubberduck.InternalApi/Model/Declarations/Execution/VBExecutionScope.cs
+++ b/Shared/Rubberduck.InternalApi/Model/Declarations/Execution/VBExecutionScope.cs
@@ -30,8 +30,11 @@ public record class VBExecutionScope : IDiagnosticSource, IExecutable
         MemberInfo = member;
         Error = error;
 
+        Diagnostics = diagnostics ?? [];
         Names = symbolTable.Select(e => e.Key.Name).ToImmutableHashSet();
     }
+
+    public ImmutableHashSet<string> Names { get; }
 
     public bool Is64BitHost { get; init; }
     public bool OptionStrict { get; init; }
@@ -41,7 +44,6 @@ public record class VBExecutionScope : IDiagnosticSource, IExecutable
     public VBTypedValue GetTypedValue(Symbol symbol) => _symbols[symbol];
     public void SetTypedValue(Symbol symbol, VBTypedValue value) => _symbols[symbol] = value;
 
-    public ImmutableHashSet<string> Names { get; }
     public VBTypeMember MemberInfo { get; init; }
 
     public VBRuntimeErrorException? Error { get; init; }
@@ -50,7 +52,7 @@ public record class VBExecutionScope : IDiagnosticSource, IExecutable
     public Symbol? ActiveGoSubReturnTo { get; init; }
     public bool ActiveErrorState => Error != null;
 
-    public IEnumerable<Diagnostic> Diagnostics { get; init; } = [];
+    public IEnumerable<Diagnostic> Diagnostics { get; init; }
 
     public VBExecutionScope WithError(VBRuntimeErrorException error) => WithDiagnostics(error.Diagnostics) with { Error = error };
     public VBExecutionScope WithDiagnostics(IEnumerable<Diagnostic> diagnostics) => this with { Diagnostics = Diagnostics.Concat(diagnostics).ToArray() };

--- a/Shared/Rubberduck.InternalApi/Model/Declarations/Symbols/ITypedSymbol.cs
+++ b/Shared/Rubberduck.InternalApi/Model/Declarations/Symbols/ITypedSymbol.cs
@@ -7,6 +7,8 @@ namespace Rubberduck.InternalApi.Model.Declarations.Symbols;
 /// </summary>
 public interface ITypedSymbol
 {
+    string? TypeName { get; }
+
     /// <summary>
     /// Gets the symbol's resolved type.
     /// </summary>

--- a/Shared/Rubberduck.InternalApi/Model/Declarations/Symbols/Symbol.cs
+++ b/Shared/Rubberduck.InternalApi/Model/Declarations/Symbols/Symbol.cs
@@ -79,12 +79,15 @@ public abstract record class Symbol : DocumentSymbol
 /// </summary>
 public abstract record class TypedSymbol : Symbol, ITypedSymbol
 {
-    public TypedSymbol(RubberduckSymbolKind kind, Accessibility accessibility, string name, WorkspaceUri? parentUri = null, IEnumerable<Symbol>? children = null, VBType? type = null)
+    public TypedSymbol(RubberduckSymbolKind kind, Accessibility accessibility, string name, WorkspaceUri? parentUri = null, IEnumerable<Symbol>? children = null, VBType? type = null, string? asTypeName = null)
         : base(kind, name, parentUri, accessibility, children)
     {
         Accessibility = accessibility;
-        ResolvedType = type;
+        ResolvedType = type ?? ResolveIntrinsicType(asTypeName);
+        TypeName = type?.Name ?? asTypeName;
     }
+
+    private VBType? ResolveIntrinsicType(string? name) => VBIntrinsicType.IntrinsicTypes.SingleOrDefault(e => e.Name == name);
 
     /// <summary>
     /// Determines whether a symbol is accessible beyond its enclosing scope.
@@ -94,13 +97,15 @@ public abstract record class TypedSymbol : Symbol, ITypedSymbol
     /// </remarks>
     public Accessibility Accessibility { get; }
 
+    public string? TypeName { get; init; }
+
     public VBType? ResolvedType { get; init; }
     public TypedSymbol WithResolvedType(VBType? resolvedType) => this with { ResolvedType = resolvedType };
 }
 
-public record class ClassTypeDefinitionSymbol : TypedSymbol
+public record class ClassTypeInstanceSymbol : TypedSymbol
 {
-    public ClassTypeDefinitionSymbol(Accessibility accessibility, string name, WorkspaceUri parentUri) 
+    public ClassTypeInstanceSymbol(Accessibility accessibility, string name, WorkspaceUri parentUri) 
         : base(RubberduckSymbolKind.Class, accessibility, name, parentUri, [], null)
     {
     }
@@ -109,7 +114,7 @@ public record class ClassTypeDefinitionSymbol : TypedSymbol
 public abstract record class DeclarationExpressionSymbol : TypedSymbol, IDeclaredTypeSymbol
 {
     protected DeclarationExpressionSymbol(RubberduckSymbolKind kind, string name, WorkspaceUri parentUri, Accessibility accessibility, IEnumerable<Symbol>? children = null, IEnumerable<IParseTreeAnnotation>? annotations = null, string? asTypeExpression = null, VBType? type = null)
-        : base(kind, accessibility, name, parentUri, children, ResolveVariantIfUnspecified(type, asTypeExpression))
+        : base(kind, accessibility, name, parentUri, children, ResolveVariantIfUnspecified(type, asTypeExpression), asTypeExpression)
     {
     }
 
@@ -206,7 +211,9 @@ public record class UserDefinedTypeSymbol : TypedSymbol
 public record class UserDefinedTypeMemberSymbol : DeclarationExpressionSymbol
 {
     public UserDefinedTypeMemberSymbol(string name, WorkspaceUri parentUri, string? asTypeExpression)
-        : base(RubberduckSymbolKind.Field, name, parentUri, Accessibility.Public, asTypeExpression: asTypeExpression) { }
+        : base(RubberduckSymbolKind.Field, name, parentUri, Accessibility.Public, asTypeExpression: asTypeExpression) 
+    {
+    }
 }
 
 public record class LibraryFunctionImportSymbol : FunctionSymbol
@@ -246,7 +253,9 @@ public record class LibraryProcedureImportSymbol : ProcedureSymbol
 public record class FunctionSymbol : TypedSymbol, IExecutable
 {
     public FunctionSymbol(string name, WorkspaceUri parentUri, Accessibility accessibility, IEnumerable<Symbol>? children = null, string? typeName = null, RubberduckSymbolKind kind = RubberduckSymbolKind.Function)
-        : base(kind, accessibility, name, parentUri, (children ?? []).ToArray()) { }
+        : base(kind, accessibility, name, parentUri, (children ?? []).ToArray(), asTypeName: typeName) 
+    {
+    }
 
     public bool? IsReachable { get; init; }
 
@@ -333,7 +342,10 @@ public record class EnumSymbol : TypedSymbol
 public record class EnumMemberSymbol : ValuedTypedSymbol
 {
     public EnumMemberSymbol(string name, WorkspaceUri parentUri, string? value)
-        : base(RubberduckSymbolKind.EnumMember, Accessibility.Public, name, parentUri, null, value) { }
+        : base(RubberduckSymbolKind.EnumMember, Accessibility.Public, name, parentUri, null, value) 
+    {
+        ResolvedType = VBLongType.TypeInfo;
+    }
 
     public override VBTypedValue Evaluate(ref VBExecutionScope context, bool rethrow = false) => context.GetTypedValue(this);
 }

--- a/Shared/Rubberduck.InternalApi/Model/Declarations/Symbols/Symbol.cs
+++ b/Shared/Rubberduck.InternalApi/Model/Declarations/Symbols/Symbol.cs
@@ -340,7 +340,7 @@ public record class EnumMemberSymbol : ValuedTypedSymbol
 
 public record class EventMemberSymbol : ProcedureSymbol
 {
-    public EventMemberSymbol(string name, WorkspaceUri parentUri, Accessibility accessibility, IEnumerable<ParameterSymbol>? parameters)
+    public EventMemberSymbol(string name, WorkspaceUri parentUri, Accessibility accessibility, IEnumerable<ParameterSymbol>? parameters = default)
         : base(name, parentUri, accessibility, parameters, RubberduckSymbolKind.Event) { }
 }
 

--- a/Shared/Rubberduck.InternalApi/Model/Declarations/Symbols/Symbol.cs
+++ b/Shared/Rubberduck.InternalApi/Model/Declarations/Symbols/Symbol.cs
@@ -23,7 +23,7 @@ public interface IValuedExpression<TValue> where TValue : VBTypedValue
 public interface IExecutable : IValuedExpression<VBTypedValue>
 {
     /// <summary>
-    /// Executes the symbol in the given context.
+    /// Executes the symbol and its children, in the given context.
     /// </summary>
     /// <returns>
     /// Returns a <c>VBTypedValue</c> representing the result of the expression; <c>null</c> if the symbol is a non-returning executable member.
@@ -338,9 +338,9 @@ public record class EnumMemberSymbol : ValuedTypedSymbol
     public override VBTypedValue Evaluate(ref VBExecutionScope context, bool rethrow = false) => context.GetTypedValue(this);
 }
 
-public record class EventMemberSymbol : ProcedureSymbol
+public record class EventSymbol : ProcedureSymbol
 {
-    public EventMemberSymbol(string name, WorkspaceUri parentUri, Accessibility accessibility, IEnumerable<ParameterSymbol>? parameters = default)
+    public EventSymbol(string name, WorkspaceUri parentUri, Accessibility accessibility, IEnumerable<ParameterSymbol>? parameters = default)
         : base(name, parentUri, accessibility, parameters, RubberduckSymbolKind.Event) { }
 }
 

--- a/Shared/Rubberduck.InternalApi/Model/Declarations/Types/Abstract/VBIntrinsicType.cs
+++ b/Shared/Rubberduck.InternalApi/Model/Declarations/Types/Abstract/VBIntrinsicType.cs
@@ -6,7 +6,7 @@ namespace Rubberduck.InternalApi.Model.Declarations.Types.Abstract;
 
 public abstract record class VBIntrinsicType : VBType
 {
-    protected static ImmutableArray<VBType> IntrinsicTypes =>
+    public static ImmutableArray<VBType> IntrinsicTypes =>
         [
             VBBooleanType.TypeInfo,
             VBByteType.TypeInfo,

--- a/Shared/Rubberduck.InternalApi/ServerPlatform/LanguageServer/ConcurrentContentStore.cs
+++ b/Shared/Rubberduck.InternalApi/ServerPlatform/LanguageServer/ConcurrentContentStore.cs
@@ -14,7 +14,7 @@ public class ConcurrentContentStore<TContent>
 
     public void AddOrUpdate(Uri documentUri, TContent content)
     {
-        Store.AddOrUpdate(documentUri, content, (uri, content) => content);
+        Store.AddOrUpdate(documentUri, content, (key, value) => content);
     }
 
     public bool TryRemove(Uri documentUri)

--- a/Shared/Rubberduck.InternalApi/ServerPlatform/LanguageServer/SupportedLanguage.cs
+++ b/Shared/Rubberduck.InternalApi/ServerPlatform/LanguageServer/SupportedLanguage.cs
@@ -1,4 +1,8 @@
-﻿namespace Rubberduck.InternalApi.ServerPlatform.LanguageServer;
+﻿using Microsoft.VisualBasic.FileIO;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using System.Linq;
+
+namespace Rubberduck.InternalApi.ServerPlatform.LanguageServer;
 
 public class SupportedLanguage
 {
@@ -20,6 +24,13 @@ public class SupportedLanguage
 
     public string Id { get; }
     public string Name { get; }
-
     public string[] FileTypes { get; }
+
+    public string FilterString => string.Join(";", FileTypes.Select(fileType => $"**/{fileType}").ToArray());
+    public TextDocumentSelector ToTextDocumentSelector() => new(
+        new TextDocumentFilter
+        {
+            Language = Id,
+            Pattern = FilterString,
+        });
 }

--- a/Shared/Rubberduck.InternalApi/Services/IWorkspaceState.cs
+++ b/Shared/Rubberduck.InternalApi/Services/IWorkspaceState.cs
@@ -1,5 +1,6 @@
 ﻿using Rubberduck.InternalApi.Extensions;
 using Rubberduck.InternalApi.Model.Declarations.Execution;
+using Rubberduck.InternalApi.Model.Workspace;
 using Rubberduck.InternalApi.ServerPlatform.LanguageServer;
 using System;
 using System.Collections.Generic;
@@ -11,8 +12,11 @@ public interface IWorkspaceState
     Uri? WorkspaceRoot { get; set; }
     string ProjectName { get; set; }
     IEnumerable<DocumentState> WorkspaceFiles { get; }
-
+    IEnumerable<Reference> References { get; }
     VBExecutionContext ExecutionContext { get; }
+
+    void AddReference(Reference reference);
+    void RemoveReference(Reference reference);
 
     bool SaveWorkspaceFile(WorkspaceFileUri uri);
     /// <summary>

--- a/Shared/Rubberduck.InternalApi/Services/IWorkspaceState.cs
+++ b/Shared/Rubberduck.InternalApi/Services/IWorkspaceState.cs
@@ -9,7 +9,7 @@ namespace Rubberduck.InternalApi.Services;
 
 public interface IWorkspaceState
 {
-    Uri? WorkspaceRoot { get; set; }
+    WorkspaceUri? WorkspaceRoot { get; set; }
     string ProjectName { get; set; }
     IEnumerable<DocumentState> WorkspaceFiles { get; }
     IEnumerable<Reference> References { get; }

--- a/Shared/Rubberduck.InternalApi/Services/IWorkspaceStateManager.cs
+++ b/Shared/Rubberduck.InternalApi/Services/IWorkspaceStateManager.cs
@@ -6,7 +6,7 @@ namespace Rubberduck.InternalApi.Services;
 
 public interface IWorkspaceStateManager
 {
-    IWorkspaceState GetWorkspace(WorkspaceUri workspaceRoot);
+    IWorkspaceState GetWorkspace(Uri workspaceRoot);
     IEnumerable<IWorkspaceState> Workspaces { get; }
     /// <summary>
     /// Gets the currently selected/active workspace/project.

--- a/Shared/Rubberduck.InternalApi/Services/IWorkspaceStateManager.cs
+++ b/Shared/Rubberduck.InternalApi/Services/IWorkspaceStateManager.cs
@@ -1,11 +1,12 @@
-﻿using System;
+﻿using Rubberduck.InternalApi.Extensions;
+using System;
 using System.Collections.Generic;
 
 namespace Rubberduck.InternalApi.Services;
 
 public interface IWorkspaceStateManager
 {
-    IWorkspaceState GetWorkspace(Uri workspaceRoot);
+    IWorkspaceState GetWorkspace(WorkspaceUri workspaceRoot);
     IEnumerable<IWorkspaceState> Workspaces { get; }
     /// <summary>
     /// Gets the currently selected/active workspace/project.

--- a/Shared/Rubberduck.InternalApi/Services/PerformanceRecordAggregator.cs
+++ b/Shared/Rubberduck.InternalApi/Services/PerformanceRecordAggregator.cs
@@ -78,7 +78,7 @@ public class PerformanceRecordAggregator
         var elapsed = TimedAction.Run(() => { bag.Clear(); });
         var verbosity = _settings.TraceLevel;
 
-        _logger.LogTrace(verbosity, $"Performance data cleared for [{name}] ({count} items). Elapsed: {elapsed}");
+        _logger.LogTrace(verbosity, $"Performance data cleared for [{name}] ({count} items). ⏱️{elapsed}");
         return true;
     }
 
@@ -122,7 +122,8 @@ public class PerformanceRecordAggregator
         });
 
         var verbosity = _settings.TraceLevel;
-        _logger.LogTrace(verbosity, $"**PERF[{name}]:{sampleSize} events. ⏱️ Total: {total} Min: {min} Max {max} Average: {average} Median: {median} Std.Dev.: {stdev} (calculations: {elapsed})");
+        _logger.LogTrace(verbosity, @$"**PERF[{name}]: {sampleSize} events. Total: ⏱️{total}
+  >>> Avg.: ⏱️{average}   Min: {min}   Max: {max}   Median: {median}    Std.Dev.: {stdev} (Calc.: {elapsed})");
     }
 
     public int Count(string name) => _items[name].Count;
@@ -141,7 +142,9 @@ public class PerformanceRecordAggregator
     {
         try
         {
-            return TotalElapsed(name) ?? TimeSpan.Zero / Count(name);
+            var total = TotalElapsed(name)?.TotalMilliseconds ?? 0;
+            var count = (double)Count(name);
+            return TimeSpan.FromMilliseconds(total / count);
         }
         catch (OverflowException)
         {

--- a/Shared/Rubberduck.InternalApi/Services/PerformanceRecordAggregator.cs
+++ b/Shared/Rubberduck.InternalApi/Services/PerformanceRecordAggregator.cs
@@ -113,7 +113,7 @@ public class PerformanceRecordAggregator
         var elapsed = TimedAction.Run(() =>
         {
             sampleSize = Count(name);
-            total = TotalElapsed(name);
+            total = TotalElapsed(name) ?? TimeSpan.Zero;
             average = AverageElapsed(name);
             stdev = StandardDeviation(name);
             min = MinElapsed(name);
@@ -122,18 +122,26 @@ public class PerformanceRecordAggregator
         });
 
         var verbosity = _settings.TraceLevel;
-        _logger.LogTrace(verbosity, $"**PERF[{name}]:{sampleSize} events. Total: {total} Min: {min} Max {max} Average: {average} Median: {median} Std.Dev.: {stdev} (calculations: {elapsed})");
+        _logger.LogTrace(verbosity, $"**PERF[{name}]:{sampleSize} events. ⏱️ Total: {total} Min: {min} Max {max} Average: {average} Median: {median} Std.Dev.: {stdev} (calculations: {elapsed})");
     }
 
     public int Count(string name) => _items[name].Count;
 
-    public TimeSpan TotalElapsed(string name) => _totals[name];
+    public TimeSpan? TotalElapsed(string name)
+    {
+        if (_totals.TryGetValue(name, out var total))
+        {
+            return total;
+        }
+
+        return null;
+    }
 
     public TimeSpan AverageElapsed(string name)
     {
         try
         {
-            return TotalElapsed(name) / Count(name);
+            return TotalElapsed(name) ?? TimeSpan.Zero / Count(name);
         }
         catch (OverflowException)
         {

--- a/Shared/Rubberduck.InternalApi/Services/ServiceBase.cs
+++ b/Shared/Rubberduck.InternalApi/Services/ServiceBase.cs
@@ -71,11 +71,25 @@ public abstract class ServiceBase
 
         if (string.IsNullOrWhiteSpace(message))
         {
-            Logger.LogError(verbosity, exception);
+            if (exception is TaskCanceledException)
+            {
+                Logger.LogWarning(verbosity, exception.Message);
+            }
+            else
+            {
+                Logger.LogError(verbosity, exception);
+            }
         }
         else
         {
-            Logger.LogError(verbosity, exception, message);
+            if (exception is TaskCanceledException)
+            {
+                Logger.LogWarning(verbosity, exception.Message);
+            }
+            else
+            {
+                Logger.LogError(verbosity, exception, message);
+            }
         }
     }
 
@@ -140,6 +154,18 @@ public abstract class ServiceBase
     {
         var verbosity = TraceLevel;
         if (TimedAction.TryRun(action, out var elapsed, out exception))
+        {
+            LogPerformanceIf(logPerformance, elapsed, name: name);
+            return true;
+        }
+
+        return false;
+    }
+
+    public bool TryRunAction(Action action, out Exception? exception, out TimeSpan elapsed, [CallerMemberName] string? name = default, bool logPerformance = true)
+    {
+        var verbosity = TraceLevel;
+        if (TimedAction.TryRun(action, out elapsed, out exception))
         {
             LogPerformanceIf(logPerformance, elapsed, name: name);
             return true;

--- a/Shared/Rubberduck.InternalApi/Services/WorkspaceService.cs
+++ b/Shared/Rubberduck.InternalApi/Services/WorkspaceService.cs
@@ -194,8 +194,9 @@ namespace Rubberduck.InternalApi.Services
                     {
                         // project source files are VB source code, always.
                         var language = projectType == ProjectType.VBA ? SupportedLanguage.VBA : SupportedLanguage.VB6;
-                        info = new SourceFileDocumentState(language, uri, content, isOpened: open && !isMissing)
+                        info = new DocumentState(uri, content, isOpened: open && !isMissing)
                         {
+                            Language = language,
                             IsMissing = isMissing,
                             IsLoadError = isLoadError
                         };

--- a/Shared/Rubberduck.InternalApi/Services/WorkspaceService.cs
+++ b/Shared/Rubberduck.InternalApi/Services/WorkspaceService.cs
@@ -72,6 +72,11 @@ namespace Rubberduck.InternalApi.Services
 
                     var state = _state.AddWorkspace(uri);
                     state.ProjectName = _fileSystem.Path.GetFileName(root);
+                    
+                    foreach (var reference in projectFile.VBProject.References)
+                    {
+                        state.AddReference(reference);
+                    }
 
                     LoadWorkspaceFiles(uri, projectFile);
                     _projectFiles.Add(projectFile);

--- a/Shared/Rubberduck.InternalApi/Services/WorkspaceService.cs
+++ b/Shared/Rubberduck.InternalApi/Services/WorkspaceService.cs
@@ -58,8 +58,10 @@ namespace Rubberduck.InternalApi.Services
                     }
 
                     var projectFile = _projectFile.ReadFile(uri);
-                    var version = new Version(projectFile.Rubberduck);
-                    if (version > new Version(ProjectFile.RubberduckVersion))
+                    var rdprojVersion = new Version(projectFile.Rubberduck);
+                    var rdVersion = new Version(ProjectFile.RubberduckVersion);
+
+                    if (rdprojVersion > new Version(ProjectFile.RubberduckVersion))
                     {
                         throw new NotSupportedException("This project was created with a version of Rubberduck greater than the one currently running.");
                     }
@@ -223,7 +225,7 @@ namespace Rubberduck.InternalApi.Services
                     {
                         LogWarning($"{(isSourceFile ? "Source file" : "File")} version {fileVersion} at {uri} was not loaded; a newer version is already cached.'.");
                     }
-                });
+                }, logPerformance: false);
             }
         }
 

--- a/Shared/Rubberduck.InternalApi/Services/WorkspaceStateManager.cs
+++ b/Shared/Rubberduck.InternalApi/Services/WorkspaceStateManager.cs
@@ -159,16 +159,16 @@ public class WorkspaceStateManager : ServiceBase, IWorkspaceStateManager
     }
 
     private Dictionary<Uri, IWorkspaceState> _workspaces = [];
-    public IWorkspaceState GetWorkspace(Uri workspaceRoot)
+    public IWorkspaceState GetWorkspace(WorkspaceUri workspaceRoot)
     {
         if (!_workspaces.Any())
         {
             throw new InvalidOperationException("Workspace data is empty.");
         }
 
-        if (!_workspaces.TryGetValue(workspaceRoot, out var value))
+        if (!_workspaces.TryGetValue(workspaceRoot.WorkspaceRoot, out var value))
         {
-            LogWarning("Workspace URI was not found.", $"{workspaceRoot}\n{string.Join("\n*", _workspaces.Keys.Select(key => key.ToString()))}");
+            LogWarning("Workspace URI was not found.", $"{workspaceRoot.WorkspaceRoot}\n{string.Join("\n*", _workspaces.Keys.Select(key => key.ToString()))}");
             throw new KeyNotFoundException("Workspace URI was not found.");
         }
 

--- a/Tests/Rubberduck.Tests/VBExecutionContextBuilder.cs
+++ b/Tests/Rubberduck.Tests/VBExecutionContextBuilder.cs
@@ -2,6 +2,7 @@
 using Rubberduck.InternalApi.Model.Declarations.Execution;
 using Rubberduck.InternalApi.Model.Declarations.Execution.Values;
 using Rubberduck.InternalApi.Model.Declarations.Symbols;
+using Rubberduck.InternalApi.Model.Declarations.Types;
 using Rubberduck.InternalApi.Model.Declarations.Types.Abstract;
 using Rubberduck.InternalApi.Services;
 using Rubberduck.InternalApi.Settings;
@@ -25,7 +26,16 @@ public class VBExecutionContextBuilder
     {
         foreach (var symbol in symbols)
         {
-            _context.AddTypedSymbol(symbol);
+            _context.AddToSymbolTable(symbol);
+        }
+        return this;
+    }
+
+    public VBExecutionContextBuilder WithClassTypes(params VBClassType[] vbTypes)
+    {
+        foreach (var vbType in vbTypes)
+        {
+            _context.AddVBType(vbType);
         }
         return this;
     }

--- a/Tests/Rubberduck.Tests/VBTypes/OperatorTests.cs
+++ b/Tests/Rubberduck.Tests/VBTypes/OperatorTests.cs
@@ -97,6 +97,6 @@ public abstract class OperatorTests : ServiceBaseTest
     protected TypedSymbol CreateClassType(VBExecutionContext context, string name, bool isUserDefined = true, bool isCreatable = true)
     {
         var type = new VBClassType(name, new Uri(ParentProjectUri.OriginalString + $"/{name}"), isUserDefined) { IsCreatable = isCreatable };
-        return new ClassTypeDefinitionSymbol(Visibility.Undefined, name, ParentProjectUri).WithResolvedType(type);
+        return new ClassTypeInstanceSymbol(Visibility.Undefined, name, ParentProjectUri).WithResolvedType(type);
     }
 }


### PR DESCRIPTION
Picks up where the pipeline PR left off, so this is about exposing the collected state and notifying the LSP client.

✅ Done already:
- [x] Adjust DI/IoC to inject parser pipelines and their dependencies
- [x] Adjust workspace & document state management to have actual workspace state in `WorkspaceStateManager`
- [x] Run parser pipeline to successful completion
- [x] Collects syntax errors
- [x] Collects folding ranges
- [x] Collects document member symbols (modules, members, parameters)

✔️ Primary Objectives:
- [x] Resolves document member symbols
- [ ] Sends [`workspace/semanticTokens/refresh`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/#semanticTokens_refreshRequest) notifications

✔️ Secondary Objectives:
- [ ] Collects hierarchical symbols (statements, instructions, expressions, etc.) 
- [ ] Resolves hierarchical symbols
- [ ] Collects semantic tokens

While resolving symbols is in-scope here, the main objective is to deliver the document symbols to the LSP client, along with any accumulated state - syntax errors, folding ranges, diagnostics, etc.; much of the necessary infrastructure is already in place, so much smaller diffs (vs previous pulls) should be expected going forward.